### PR TITLE
Three commits to fix typos, enable sub directory traversing with command line parameters, and enable Python 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ endif
 #
 # GOALS    = mux
 # SO_GOALS = libsharedLibrary.so
-# AR_GOALS = archiveLibrary.so
+# AR_GOALS = archiveLibrary.a
 
 #
 #    Define the list of alternate source directories.  This is a space or colon

--- a/api/Makefile
+++ b/api/Makefile
@@ -194,7 +194,7 @@ endif
 #
 # GOALS    = mux
 # SO_GOALS = libsharedLibrary.so
-# AR_GOALS = archiveLibrary.so
+# AR_GOALS = archiveLibrary.a
 
 SO_GOALS = libvsi-api.so
 

--- a/build/master.mk
+++ b/build/master.mk
@@ -645,15 +645,16 @@ $(SUBDIRS): $(GOAL_LIST)
 #
 .PHONY: subdirs $(SUBDIRS)
 subdirs: $(SUBDIRS)
-
 $(SUBDIRS):
 	curdir=$(subst $(TOP)/,,$(CURDIR)/$@); \
 	$(DIR_ECHO) "===> [$(MAKELEVEL)] Moving into $$curdir ..."; \
-	$(MAKE) MAKEFLAGS=$(MAKEFLAGS) -C $@ $(MAKECMDGOALS); \
+	cd $@; \
+	$(MAKE) MAKEFLAGS=$(MAKEFLAGS) $(MAKECMDGOALS); \
 	if [ $$? -ne 0 ]; \
 	then \
 	    exit 255; \
 	fi; \
+	cd ..; \
 	$(DIR_ECHO) "<=== [$(MAKELEVEL)] Moving out of $$curdir"
 
 #

--- a/core/Makefile
+++ b/core/Makefile
@@ -193,7 +193,7 @@ endif
 #    directory.
 #
 # SO_GOALS = libsharedLibrary.so
-# AR_GOALS = archiveLibrary.so
+# AR_GOALS = archiveLibrary.a
 
 SO_GOALS = libvsi-core.so
 

--- a/lua-interfaces/Makefile
+++ b/lua-interfaces/Makefile
@@ -194,7 +194,7 @@ endif
 #
 # GOALS    = mux
 # SO_GOALS = libsharedLibrary.so
-# AR_GOALS = archiveLibrary.so
+# AR_GOALS = archiveLibrary.a
 
 SO_GOALS = liblua_vsi_core.so liblua_vsi_api.so liblua_vsi.so
 

--- a/python-interfaces/Makefile
+++ b/python-interfaces/Makefile
@@ -370,7 +370,21 @@ include $(TOP)/build/master.mk
 #
 # INCLUDE_DIRS += -I../some/path/to/include/files
 
-INCLUDE_DIRS += -I/usr/include/python3.5m
+# Make this work for Python 2 and Python 3
+ifndef PYTHON_VERSION
+	python_version_full := $(wordlist 2,4,$(subst ., ,$(shell python --version 2>&1)))
+	python_version_major := $(word 1,${python_version_full})
+	python_version_minor := $(word 2,${python_version_full})
+	python_version_patch := $(word 3,${python_version_full})
+
+	PYTHON_VERSION ?= ${python_version_major}.${python_version_minor}
+
+	ifeq ($(python_version_major),3)
+		PYTHON_VERSION := ${PYTHON_VERSION}m
+	endif
+endif
+
+INCLUDE_DIRS += -I/usr/include/python${PYTHON_VERSION}
 
 #
 #    Define any additional link flags that need to be used to form the "goal"


### PR DESCRIPTION
* In the Makefile comments the example for AR_GOALS was archiveLibrary.so when it should be archiveLibrary.a.
* When passing a parameter in the form of FOO=BAR the build would fail when traversing sub directories. Traversal was done using the -C <subdir> parameter to make. It's not clear why that caused the issue of circular dependencies. However, using cd <subdir> resolves the issue.
* The Python integration only worked with Python 3. Made it work with Python 2 and 3.