### PR TITLE
Fixes to build system for native and cross compiling

### DIFF
--- a/build/master.mk
+++ b/build/master.mk
@@ -544,7 +544,6 @@ endif
 #
 #    Define the flags and commands to compile a C file.
 #
-undefine CC
 CC              ?= gcc
 CC_OPTIMIZATION = $(OPTIMIZATION)
 CC_INCLUDES     = $(COMMON_INCLUDES)
@@ -555,7 +554,6 @@ CC_CMD          = $(CC) $(CC_FLAGS)
 #
 #    Define the flags and commands to compile a C++ file.
 #
-undefine CXX
 CXX              ?= g++
 CXX_OPTIMIZATION = $(OPTIMIZATION)
 CXX_INCLUDES     = $(COMMON_INCLUDES)
@@ -566,7 +564,6 @@ CXX_CMD          = $(CXX) $(CXX_FLAGS)
 #
 #    Define the flags and commands to link C++ files.
 #
-undefine LD
 LD               ?= gcc
 LD_OPTIMIZATION  = $(OPTIMIZATION)
 override LD_FLAGS += $(LD_OPTIMIZATION)
@@ -652,7 +649,7 @@ $(SUBDIRS):
 	curdir=$(subst $(TOP)/,,$(CURDIR)/$@); \
 	$(DIR_ECHO) "===> [$(MAKELEVEL)] Moving into $$curdir ..."; \
 	cd $@; \
-	$(MAKE) MAKEFLAGS=$(MAKEFLAGS) $(MAKECMDGOALS); \
+	$(MAKE) --no-builtin-variables MAKEFLAGS=$(MAKEFLAGS) $(MAKECMDGOALS); \
 	if [ $$? -ne 0 ]; \
 	then \
 	    exit 255; \

--- a/build/master.mk
+++ b/build/master.mk
@@ -544,6 +544,7 @@ endif
 #
 #    Define the flags and commands to compile a C file.
 #
+undefine CC
 CC              ?= gcc
 CC_OPTIMIZATION = $(OPTIMIZATION)
 CC_INCLUDES     = $(COMMON_INCLUDES)
@@ -554,6 +555,7 @@ CC_CMD          = $(CC) $(CC_FLAGS)
 #
 #    Define the flags and commands to compile a C++ file.
 #
+undefine CXX
 CXX              ?= g++
 CXX_OPTIMIZATION = $(OPTIMIZATION)
 CXX_INCLUDES     = $(COMMON_INCLUDES)
@@ -564,6 +566,7 @@ CXX_CMD          = $(CXX) $(CXX_FLAGS)
 #
 #    Define the flags and commands to link C++ files.
 #
+undefine LD
 LD               ?= gcc
 LD_OPTIMIZATION  = $(OPTIMIZATION)
 override LD_FLAGS += $(LD_OPTIMIZATION)

--- a/python-interfaces/Makefile
+++ b/python-interfaces/Makefile
@@ -370,7 +370,9 @@ include $(TOP)/build/master.mk
 #
 # INCLUDE_DIRS += -I../some/path/to/include/files
 
-# Make this work for Python 2 and Python 3
+#
+# Add a define so that we can compile this for Python 2 and Python 3
+#
 ifndef PYTHON_VERSION
 	python_version_full := $(wordlist 2,4,$(subst ., ,$(shell python --version 2>&1)))
 	python_version_major := $(word 1,${python_version_full})
@@ -384,7 +386,7 @@ ifndef PYTHON_VERSION
 	endif
 endif
 
-INCLUDE_DIRS += -I=/usr/include/python${PYTHON_VERSION}
+DEFINES += -DPYTHON_VERSION=$(PYTHON_VERSION)
 
 #
 #    Define any additional link flags that need to be used to form the "goal"

--- a/python-interfaces/vsi_py.c
+++ b/python-interfaces/vsi_py.c
@@ -1,5 +1,12 @@
 
-#include <Python.h>
+#define IPATH python PYTHON_VERSION
+#define IFILE Python.h
+
+#define __header(x) #x
+#define _header(p,f) __header(p/f)
+#define header(p,f) _header(p,f)
+#include header(IPATH,IFILE)
+
 
 //
 //  Define the following symbol to get debugging output.  Note: You may get


### PR DESCRIPTION
There were still some issues with native and cross compiling where one would not work but the other.

One issue are the built-in variables of make such as CC, CXX, LD, etc. In this case LD was the culprit. If you assign LD = gcc then you cannot override it from the command line. However, if you use LD ?= gcc then you can override it from the command line but if not overridden then the default setting of LD, which is ld always applies. That causes issues when linking natively. The solution is to pass --no-builtin-variables (or -R) to make. Unfortunately, there is no setting you can use from inside the makefile. However, for this build system this is a non-issue as make is called for every subdirectory. Therefore, I added the setting to the call to make.

Another issue arose from adding the include path for the Python.h header for various Python versions. The approach, for some reason, did not work for native compliation. I therefore used some pre-processor trickery to compute the include path based on the PYTHON_VERSION passed to the compiler.

