### PR TITLE
Replace all TAB characters with 4 spaces

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -46,22 +46,22 @@ not be defined here again.
 #### vsi_result
 
 ```C
-	typedef struct vsi_result
-	{
-		pthread_mutex_t lock;
+    typedef struct vsi_result
+    {
+        pthread_mutex_t lock;
 
-		vsi_context*    context;
+        vsi_context*    context;
 
-		domain_t        domainId;
-		signal_t        signalId;
-		char*           name;
+        domain_t        domainId;
+        signal_t        signalId;
+        char*           name;
 
-		char*           data;
-		unsigned long   dataLength;
+        char*           data;
+        unsigned long   dataLength;
 
-		int             status;
+        int             status;
 
-	}   vsi_result;
+    }   vsi_result;
 ```
 
 Many of the functions in the VSI API take a ```vsi_result``` structure as an
@@ -548,11 +548,11 @@ the result structures.
 #### vsi_listen_any_in_group
 
 ```C
-	int vsi_listen_any_in_group ( vsi_handle    handle,
-								  const group_t groupId,
-								  unsigned int  timeout,
-								  domain_t*     domainId,
-								  signal_t*     signalId );
+    int vsi_listen_any_in_group ( vsi_handle    handle,
+                                  const group_t groupId,
+                                  unsigned int  timeout,
+                                  domain_t*     domainId,
+                                  signal_t*     signalId );
 ```
 
 This function will listen for any signal in the specified group.  The signal
@@ -584,11 +584,11 @@ caller within the domain specified.
 #### vsi_listen_all_in_group
 
 ```C
-	int vsi_listen_all_in_group ( vsi_handle    handle,
-								  const group_t groupId,
-								  vsi_result*   results,
-								  unsigned int  resultsSize,
-								  unsigned int  timeout );
+    int vsi_listen_all_in_group ( vsi_handle    handle,
+                                  const group_t groupId,
+                                  vsi_result*   results,
+                                  unsigned int  resultsSize,
+                                  unsigned int  timeout );
 ```
 
 This function will listen for all signals in the specified group.  The signal
@@ -658,10 +658,10 @@ vice versa.
                                   char**         name,
                                   unsigned int   nameLength );
 
-	int vsi_define_signal_name ( vsi_handle     handle,
-								 const domain_t domainId,
-								 const signal_t signalId,
-								 const char*    name );
+    int vsi_define_signal_name ( vsi_handle     handle,
+                                 const domain_t domainId,
+                                 const signal_t signalId,
+                                 const char*    name );
 ```
 
 The vsi_name_string_to_id function takes a signal name and returns the domain

--- a/api/tests/importVSS.c
+++ b/api/tests/importVSS.c
@@ -9,7 +9,7 @@
 
 /*!----------------------------------------------------------------------------
 
-	@file      importVSS.c
+    @file      importVSS.c
 
     This file will read a Vehicle Signal Specification (VSS) format file and
     write all of the signal definitions into the Vehicle Signal Interface
@@ -53,7 +53,7 @@ typedef struct userData
 
     b t r e e   S u p p o r t   F u n c t i o n s
 
-	The following functions will support various functions in the btree
+    The following functions will support various functions in the btree
     library.
 
 ------------------------------------------------------------------------*/
@@ -97,11 +97,11 @@ static void traverseFunction ( char* leader, void* dataPtr )
 
 /*!-----------------------------------------------------------------------
 
-	m a i n
+    m a i n
 
-	@brief The main entry point for this VSS demonstration program.
+    @brief The main entry point for this VSS demonstration program.
 
-	This function will read the supplied VSS definition file and build the
+    This function will read the supplied VSS definition file and build the
     data structures to support it in memory.  It will build 2 indices on that
     data, one to fetch the name of something given it's domain and signal ID,
     and the other to fetch the domain and signal ID given the signal name.

--- a/api/tests/sample.c
+++ b/api/tests/sample.c
@@ -40,8 +40,8 @@ void printFunction ( char* leader, void* data )
     vsi_id_name_definition* userDataPtr = data;
 
     printf ( "%sUserData: domainId: %lu, signalId: %lu, privateId: %lu, name[%s]\n",
-			 leader, userDataPtr->domainId, userDataPtr->signalId,
-			 userDataPtr->privateId, userDataPtr->name );
+             leader, userDataPtr->domainId, userDataPtr->signalId,
+             userDataPtr->privateId, userDataPtr->name );
 }
 
 
@@ -81,10 +81,10 @@ static int storeSignal ( vsi_result* result, domain_t domain_id,
 
     m a i n
 
-	This function will test much of the functionality of the VSI API
+    This function will test much of the functionality of the VSI API
     functions.
 
-	@param[in] None
+    @param[in] None
 
 ------------------------------------------------------------------------*/
 int main()

--- a/api/vsi.c
+++ b/api/vsi.c
@@ -166,7 +166,7 @@ void printGroupFunction ( char* leader, void* data )
     //
     if ( current == NULL )
     {
-		printf ( "%s  Group has no members defined.\n", leader );
+        printf ( "%s  Group has no members defined.\n", leader );
         return;
     }
     //
@@ -303,10 +303,10 @@ int vsi_VSS_import ( vsi_handle handle, const char* fileName )
         fprintf ( stderr, "ERROR: NULL VSS input file specified.\n" );
         return ENOENT;
     }
-	//
-	//  Attempt to open the specified file.
-	//
-	inputFile = fopen ( fileName, "r" );
+    //
+    //  Attempt to open the specified file.
+    //
+    inputFile = fopen ( fileName, "r" );
 
     //
     //  If we could not open the file that was specified complain and quit.
@@ -695,7 +695,7 @@ int vsi_delete_signal_group ( vsi_handle    handle,
     //
     //  Get the group object that the user specified.
     //
-	vsi_signal_group  group;
+    vsi_signal_group  group;
     vsi_signal_group* temp;
 
     group.groupId = groupId;
@@ -758,9 +758,9 @@ int vsi_delete_signal_group ( vsi_handle    handle,
 
     v s i _ a d d _ s i g n a l _ t o _ g r o u p
 
-	@brief Add a new signal to the specified group.
+    @brief Add a new signal to the specified group.
 
-	This function will add a new signal to the specified group.
+    This function will add a new signal to the specified group.
 
 ------------------------------------------------------------------------*/
 int vsi_add_signal_to_group ( vsi_handle     handle,
@@ -806,9 +806,9 @@ int vsi_add_signal_to_group ( vsi_handle     handle,
 
     v s i _ a d d _ s i g n a l _ t o _ g r o u p _ b y _ n a m e
 
-	@brief Add a new signal to the specified group by name.
+    @brief Add a new signal to the specified group by name.
 
-	This function will add a new signal to the specified group.
+    This function will add a new signal to the specified group.
 
 ------------------------------------------------------------------------*/
 int vsi_add_signal_to_group_by_name ( vsi_handle    handle,
@@ -828,9 +828,9 @@ int vsi_add_signal_to_group_by_name ( vsi_handle    handle,
 
     v s i _ r e m o v e _ s i g n a l _ f r o m _ g r o u p
 
-	@brief Remove a signal from the specified group.
+    @brief Remove a signal from the specified group.
 
-	This function will add a new signal to the specified group.
+    This function will add a new signal to the specified group.
 
     TODO: This removal is awkward.  We need to search for the item we want and
     then call the remove function which will perform another search for the
@@ -886,9 +886,9 @@ int vsi_remove_signal_from_group ( vsi_handle     handle,
 
     v s i _ r e m o v e _ s i g n a l _ f r o m _ g r o u p _ b y _ n a m e
 
-	@brief Remove a signal from the specified group by name.
+    @brief Remove a signal from the specified group by name.
 
-	This function will add a new signal to the specified group.
+    This function will add a new signal to the specified group.
 
 ------------------------------------------------------------------------*/
 int vsi_remove_signal_from_group_by_name ( vsi_handle    handle,
@@ -917,9 +917,9 @@ int vsi_remove_signal_from_group_by_name ( vsi_handle    handle,
 
     v s i _ g e t _ n e w e s t _ i n _ g r o u p
 
-	@brief Get the newest signal available for all signals in a group.
+    @brief Get the newest signal available for all signals in a group.
 
-	This function will fetch the newest (the one with the most recent
+    This function will fetch the newest (the one with the most recent
     timestamp) signal available for each member signal in the specified group.
 
     Note that the result pointer in this case MUST be a pointer to an array of
@@ -1083,9 +1083,9 @@ int vsi_get_newest_in_group_wait ( vsi_handle    handle,
 
     v s i _ g e t _ o l d e s t _ i n _ g r o u p
 
-	@brief Get the oldest signal available for all signals in a group.
+    @brief Get the oldest signal available for all signals in a group.
 
-	This function will fetch the oldest (the one with the least recent
+    This function will fetch the oldest (the one with the least recent
     timestamp) signal available for each member signal in the specified group.
 
     Note that the result pointer in this case MUST be a pointer to an array of
@@ -1839,7 +1839,7 @@ int vsi_listen_all_in_group ( vsi_handle    handle,
 
     v s i _ f l u s h _ g r o u p
 
-	@brief Flush all of the signals available for all signals in a group.
+    @brief Flush all of the signals available for all signals in a group.
 
     This function will flush all of the signals available for each member
     signal in the specified group.
@@ -1851,7 +1851,7 @@ int vsi_listen_all_in_group ( vsi_handle    handle,
 
 ------------------------------------------------------------------------*/
 int vsi_flush_group ( vsi_handle    handle,
-                      const group_t groupId )
+        const group_t groupId )
 {
     vsi_signal_group        group;
     vsi_signal_group*       temp = 0;
@@ -1955,7 +1955,7 @@ int vsi_flush_group ( vsi_handle    handle,
 
 ------------------------------------------------------------------------*/
 int vsi_name_string_to_id ( vsi_handle  handle,
-						    const char* name,
+                            const char* name,
                             domain_t*   domainId,
                             signal_t*   signalId )
 {

--- a/api/vsi.h
+++ b/api/vsi.h
@@ -38,7 +38,7 @@
 
 
 //
-//  Determine how the various macros will be intrepreted depending on which
+//  Determine how the various macros will be interpreted depending on which
 //  options have been enabled.
 //
 #ifdef VSI_DEBUG
@@ -68,9 +68,9 @@
 
     C o n f i g u r a t i o n   S e t t i n g s
 
-	@brief Define the system configuration settings.
+    @brief Define the system configuration settings.
 
-	The following definitions should be customized to suit the user's specific
+    The following definitions should be customized to suit the user's specific
     environment.
 
 -----------------------------------------------------------------------------*/
@@ -111,11 +111,11 @@ typedef enum
 
 /*!-----------------------------------------------------------------------
 
-	s t r u c t   v s i _ c o n t e x t
+    s t r u c t   v s i _ c o n t e x t
 
-	@brief The master handle structure that gets passed to all VSI functions
+    @brief The master handle structure that gets passed to all VSI functions
 
-	This data structure is the "handle" object that gets passed to all of the
+    This data structure is the "handle" object that gets passed to all of the
     VSI functions.  All of the master data objects in the VSI system are
     defined as members of this structure.
 
@@ -239,7 +239,7 @@ typedef struct vsi_result
 
     s t r u c t   v s i _ i d _ n a m e _ d e f i n i t i o n
 
-	@brief This data structure is designed to hold the Id and name of each
+    @brief This data structure is designed to hold the Id and name of each
     signal defined in the system.
 
     This defines the "user data" structure that will be used to build the
@@ -267,9 +267,9 @@ typedef struct vsi_id_name_definition
 
     s t r u c t   v s i _ s i g n a l _ g r o u p
 
-	@brief This data structure manages lists of signals in a group.
+    @brief This data structure manages lists of signals in a group.
 
-	This defines the data structure that keeps track of groups and the signals
+    This defines the data structure that keeps track of groups and the signals
     that belong to each group.  This catagorization is accomplished with
     another btree that is indexed by the group Id.  Each group then contains a
     list of all of the signals that have been registered for that group.
@@ -336,15 +336,15 @@ int vsi_destroy ( vsi_handle handle );
 
     v s i _ V S S _ i m p o r t
 
-	@brief Import a VSS file into the VSI data store.
+    @brief Import a VSS file into the VSI data store.
 
-	This function will read the specified file and import the contents of it
+    This function will read the specified file and import the contents of it
     into the specified VSI environment.
 
-	@param[in] - handle - The VSI context handle
-	@param[in] - fileName - The pathname to the VSS definition file to be read
+    @param[in] - handle - The VSI context handle
+    @param[in] - fileName - The pathname to the VSS definition file to be read
 
-	@return - Completion code - 0 = Succesful
+    @return - Completion code - 0 = Succesful
                                 Anything else is an error code
 
 -----------------------------------------------------------------------------*/

--- a/api/vsi_list.c
+++ b/api/vsi_list.c
@@ -20,17 +20,17 @@
 
     v s i _ l i s t _ i n i t i a l i z e
 
-	@brief Initialize a new list data structure.
+    @brief Initialize a new list data structure.
 
-	This function will initialize a new list data structure by initializing
+    This function will initialize a new list data structure by initializing
     all of the fields in the structure and initializing the list mutex lock.
 
     This function should be called when a new list is created before any data
     is inserted into the list.
 
-	@param[in] list - The address of the list structure to initialize
+    @param[in] list - The address of the list structure to initialize
 
-	@return status - 0: Success
+    @return status - 0: Success
                     ~0: An error code
 
 ------------------------------------------------------------------------*/
@@ -59,16 +59,16 @@ int vsi_list_initialize ( vsi_list* list )
 
     v s i _ l i s t _ i n s e r t
 
-	@brief Insert a new data record into the specified list.
+    @brief Insert a new data record into the specified list.
 
-	This function will create a new list entry record, initialize it, put the
+    This function will create a new list entry record, initialize it, put the
     specified pointer into it, and then insert this new record at the tail of
     the specified list.
 
-	@param[in] list - The address of the list to insert into
-	@param[in] record - The address of the data record to insert into the list.
+    @param[in] list - The address of the list to insert into
+    @param[in] record - The address of the data record to insert into the list.
 
-	@return status - 0: Success
+    @return status - 0: Success
                     ~0: An error code
 
 ------------------------------------------------------------------------*/
@@ -146,16 +146,16 @@ int vsi_list_insert ( vsi_list* list, void* record )
 
     v s i _ l i s t _ r e m o v e
 
-	@brief Remove the specified record from the specified list
+    @brief Remove the specified record from the specified list
 
-	This function will find the specifield data record in the specified list,
+    This function will find the specifield data record in the specified list,
     remove that record from the list and update the list count.
 
-	@param[in] list - The address of the list to insert into
-	@param[in] record - The address of the data record to be removed from the
-                        list.
+    @param[in] list - The address of the list to insert into
+    @param[in] record - The address of the data record to be removed from the
+    list.
 
-	@return status - 0: Success
+    @return status - 0: Success
                     ~0: An error code
 
 ------------------------------------------------------------------------*/
@@ -248,7 +248,7 @@ int vsi_list_remove ( vsi_list* list, void* record )
 
     v s i _ l i s t _ r e m o v e _ h e a d
 
-	@brief Remove a data record from the specified list.
+    @brief Remove a data record from the specified list.
 
     This function will find the specified data record in the specified list
     and remove that record from the list.  The removed data pointer will be
@@ -257,10 +257,10 @@ int vsi_list_remove ( vsi_list* list, void* record )
     Note that if the specified list is empty then a NULL pointer will be
     returned to the caller.
 
-	@param[in] list - The address of the list to search
-	@param[in] record - The address of where to store the removed record
+    @param[in] list - The address of the list to search
+    @param[in] record - The address of where to store the removed record
 
-	@return status - 0: Success
+    @return status - 0: Success
                     ~0: An error code
 
 ------------------------------------------------------------------------*/

--- a/core/btree.c
+++ b/core/btree.c
@@ -9,9 +9,9 @@
 
 /*!----------------------------------------------------------------------------
 
-	@file btree.c
+    @file btree.c
 
-	This file implements the shared memory capable btree data structure code.
+    This file implements the shared memory capable btree data structure code.
 
     TODO: Change the iterator api to allocate iterators only when needed,
     otherwise, reuse an existing iterator.
@@ -105,8 +105,8 @@ static bt_node_t* merge_siblings ( btree_t* btree,
                                    unsigned int index );
 
 static void btree_traverse_node ( btree_t*     btree,
-                           bt_node_t*   subtree,
-                           traverseFunc traverseFunction );
+                                  bt_node_t*   subtree,
+                                  traverseFunc traverseFunction );
 
 static int btree_compare_function ( btree_t* btree,
                                     void* data1,
@@ -153,9 +153,9 @@ inline static bool isLeaf ( bt_node_t* node )
 
 
 //
-//	Define the local functions that convert node offsets to addresses and vice
-//	versa.  Some of these are defined as static functions to give the compiler
-//	the option of inlining them if it wants.
+//  Define the local functions that convert node offsets to addresses and vice
+//  versa.  Some of these are defined as static functions to give the compiler
+//  the option of inlining them if it wants.
 //
 inline static void* cvtToAddr ( btree_t* btree,
                                 offset_t offset )
@@ -498,15 +498,15 @@ static void mutexCleanupHandler ( void* arg )
 
     b t r e e _ i n i t i a l i z e
 
-	@brief Initialize all of the btree parameters.
+    @brief Initialize all of the btree parameters.
 
     This function will initialize all of the parameters that we will use to
     build any of the btrees the user wants to define.  This only needs to be
     done once since the parameters are the same of every node of each btree.
 
-	@param[in] - handle - The base address of the shared memory segment.
+    @param[in] - handle - The base address of the shared memory segment.
 
-	@return  0 - Everything was created without error.
+    @return  0 - Everything was created without error.
             !0 - There was an error in the process.
 
 -----------------------------------------------------------------------------*/
@@ -586,9 +586,9 @@ void btree_initialize ( btree_t*     btree,
 
     b t r e e _ c r e a t e
 
-	@brief Create a new btree instance.
+    @brief Create a new btree instance.
 
-	This function is used to create a btree with just an empty root node.
+    This function is used to create a btree with just an empty root node.
     Once this function is called, the btree is ready to use.
 
     All of the arguments are callback functions that will be used to
@@ -647,9 +647,9 @@ btree_t* btree_create ( unsigned int maxRecordsPerNode,
 
     b t r e e _ c r e a t e _ i n _ p l a c e
 
-	@brief Create a new B-tree instance.
+    @brief Create a new B-tree instance.
 
-	This function will create a new B-tree instance for those cases in which
+    This function will create a new B-tree instance for those cases in which
     the caller wants to supply the btree_t data structure.  This function is
     identical to the "btree_create" function above except for who allocates
     the storage for the B-tree data.
@@ -698,15 +698,15 @@ void btree_create_in_place ( btree_t*     btree,
 
     b t r e e _ c r e a t e _ s y s
 
-	@brief
+    @brief
 
-	This function will
+    This function will
 
-	@param[in]
-	@param[out]
-	@param[in,out]
+    @param[in]
+    @param[out]
+    @param[in,out]
 
-	@return None
+    @return None
 
 -----------------------------------------------------------------------------*/
 btree_t* btree_create_sys ( btree_t*     btree,
@@ -740,15 +740,15 @@ btree_t* btree_create_sys ( btree_t*     btree,
 
     i n i t _ n o d e _ h e a d e r
 
-	@brief Initialize a B-tree node header.
+    @brief Initialize a B-tree node header.
 
-	This function will
+    This function will
 
-	@param[in]
-	@param[out]
-	@param[in,out]
+    @param[in]
+    @param[out]
+    @param[in,out]
 
-	@return None
+    @return None
 
 -----------------------------------------------------------------------------*/
 static void init_node_header ( btree_t* btree,
@@ -808,13 +808,13 @@ static void init_node_header ( btree_t* btree,
 
     a l l o c a t e _ b t r e e _ n o d e
 
-	@brief Allocate a new btree node.
+    @brief Allocate a new btree node.
 
-	This function will allocate a new btree node structure and initialize it.
+    This function will allocate a new btree node structure and initialize it.
 
-	@param[in] btree - The address of the btree being extended.
+    @param[in] btree - The address of the btree being extended.
 
-	@return The address of the newly allocated btree node structure.
+    @return The address of the newly allocated btree node structure.
             NULL if there was an error allocating the node.
 
 -----------------------------------------------------------------------------*/
@@ -863,15 +863,15 @@ static bt_node_t* allocate_btree_node ( btree_t* btree )
 
     f r e e _ b t r e e _ n o d e
 
-	@brief Deallocate an existing btree node strructure.
+    @brief Deallocate an existing btree node strructure.
 
-	This function will deallocate the memory used by an existing btree node
+    This function will deallocate the memory used by an existing btree node
     data structure.
 
-	@param[in] btree - The address of the btree control structure.
-	@param[in] node - The address of the btree node to be deallocated.
+    @param[in] btree - The address of the btree control structure.
+    @param[in] node - The address of the btree node to be deallocated.
 
-	@return None
+    @return None
 
 -----------------------------------------------------------------------------*/
 static void free_btree_node ( btree_t*   btree,
@@ -911,9 +911,9 @@ static void free_btree_node ( btree_t*   btree,
 
     b t r e e _ s p l i t _ c h i l d
 
-	@brief Split a child node.
+    @brief Split a child node.
 
-	This function will split the specified child node into 2 nodes and move
+    This function will split the specified child node into 2 nodes and move
     the data at the "index" position in the original node up to the parent
     node (at the appropriate place).
 
@@ -925,12 +925,12 @@ static void free_btree_node ( btree_t*   btree,
     node from past the midpoint to the end of the node will be moved into the
     new child node starting at index 0.
 
-	@param[in] btree - The btree to operate on
-	@param[in] parent - The address of the parent node
-	@param[in] index - The index position in the parent to insert the new record
-	@param[in] child - The address of the child node to be split
+    @param[in] btree - The btree to operate on
+    @param[in] parent - The address of the parent node
+    @param[in] index - The index position in the parent to insert the new record
+    @param[in] child - The address of the child node to be split
 
-	@return None
+    @return None
 
 -----------------------------------------------------------------------------*/
 static void btree_split_child ( btree_t*     btree,
@@ -938,7 +938,7 @@ static void btree_split_child ( btree_t*     btree,
                                 unsigned int index,
                                 bt_node_t*   child )
 {
-	int          i;
+    int          i;
     unsigned int min       = btree->min;
     unsigned int minDegree = btree->minDegree;
     bt_node_t*   newChild  = 0;
@@ -993,7 +993,7 @@ static void btree_split_child ( btree_t*     btree,
             //  point to the new child rather than the old child from which it
             //  was moved.
             //
-			getLeftChild ( btree, newChild, i )->parent =
+            getLeftChild ( btree, newChild, i )->parent =
                 cvtToOffset ( btree, newChild );
         }
     }
@@ -1061,9 +1061,9 @@ static void btree_split_child ( btree_t*     btree,
 
     b t r e e _ i n s e r t _ n o n f u l l
 
-	@brief Insert a record into a non-full node.
+    @brief Insert a record into a non-full node.
 
-	This function will insert a record into a non-full node.
+    This function will insert a record into a non-full node.
 
     TODO: We could make the node search more efficient by implementing a
     binary search instead of the linear one.  For small tree orders, the
@@ -1071,10 +1071,10 @@ static void btree_split_child ( btree_t*     btree,
     binary search will win.
 
     @param[in] btree - The btree to operate on
-	@param[in] parent - The address of the parent node
-	@param[in] data - The address of the data to be inserted
+    @param[in] parent - The address of the parent node
+    @param[in] data - The address of the data to be inserted
 
-	@return None
+    @return None
 
 -----------------------------------------------------------------------------*/
 static void btree_insert_nonfull ( btree_t*   btree,
@@ -1196,14 +1196,14 @@ insert:
 
     b t r e e _ i n s e r t
 
-	@brief Insert a new data record into the btree.
+    @brief Insert a new data record into the btree.
 
-	This function will insert a new data record into the specified btree.
+    This function will insert a new data record into the specified btree.
 
     @param[in] btree - The btree to operate on
-	@param[in] data - The address of the data to be inserted
+    @param[in] data - The address of the data to be inserted
 
-	@return Always 0!  TODO: Fix this?
+    @return Always 0!  TODO: Fix this?
 
 -----------------------------------------------------------------------------*/
 int btree_insert ( btree_t* btree, void* data )
@@ -1313,15 +1313,15 @@ int btree_insert ( btree_t* btree, void* data )
 
     g e t _ m a x _ k e y _ p o s
 
-	@brief Used to get the position of the maximum key within the subtree.
+    @brief Used to get the position of the maximum key within the subtree.
 
-	This function will find the position of the maximum key within the
+    This function will find the position of the maximum key within the
     subtree.
 
     @param[in] btree - The btree to operate on
-	@param[in] subtree - The address of the root node of the subtree to search.
+    @param[in] subtree - The address of the root node of the subtree to search.
 
-	@return nodePosition - The position of the maximum data value in the subtree.
+    @return nodePosition - The position of the maximum data value in the subtree.
                            If the returned node value is zero, this tree is
                            empty.
 
@@ -1371,15 +1371,15 @@ static nodePosition get_max_key_pos ( btree_t*   btree,
 
     g e t _ m i n _ k e y _ p o s
 
-	@brief Used to get the position of the minimum key within the subtree.
+    @brief Used to get the position of the minimum key within the subtree.
 
-	This function will find the position of the minimum key within the
+    This function will find the position of the minimum key within the
     subtree.
 
     @param[in] btree - The btree to operate on
-	@param[in] subtree - The address of the root node of the subtree to search.
+    @param[in] subtree - The address of the root node of the subtree to search.
 
-	@return nodePosition - The position of the minimum data value in the subtree.
+    @return nodePosition - The position of the minimum data value in the subtree.
                            If the returned node value is zero, the btree is
                            empty.
 
@@ -1432,7 +1432,7 @@ static nodePosition get_min_key_pos ( btree_t*   btree,
 
     m e r g e _ s i b l i n g s
 
-	@brief Merge 2 child nodes into one.
+    @brief Merge 2 child nodes into one.
 
     This function will merge the 2 child nodes of the record defined by the
     parent node and index values into a single node.  The left child of the
@@ -1444,15 +1444,15 @@ static nodePosition get_min_key_pos ( btree_t*   btree,
 
     This function makes some assumptions:
 
-        The left and right children both have min records.
-        The parent has at least one record.
+    The left and right children both have min records.
+    The parent has at least one record.
 
-	@param[in] btree - The btree to operate on
-	@param[in] parent - The address of the parent node
-	@param[in] index - The index in the parent node whose children are being
+    @param[in] btree - The btree to operate on
+    @param[in] parent - The address of the parent node
+    @param[in] index - The index in the parent node whose children are being
                        merged.
 
-	@return The address of the new merged node.
+    @return The address of the new merged node.
 
 -----------------------------------------------------------------------------*/
 static bt_node_t* merge_siblings ( btree_t*     btree,
@@ -1572,18 +1572,18 @@ static bt_node_t* merge_siblings ( btree_t*     btree,
 
     m o v e _ k e y
 
-	@brief Move a record between the left and right siblings of the specified
+    @brief Move a record between the left and right siblings of the specified
     node.
 
     This function will move a record between the left and right siblings of
     the specified node.
 
-	@param[in] btree - The address of the btree to operate on
-	@param[in] node - The address of the node to move the key out of
-	@param[in] index - The position of the key within the node to be moved
-	@param[in] pos - The left/right indicator for the destination child
+    @param[in] btree - The address of the btree to operate on
+    @param[in] node - The address of the node to move the key out of
+    @param[in] index - The position of the key within the node to be moved
+    @param[in] pos - The left/right indicator for the destination child
 
-	@return None
+    @return None
 
 -----------------------------------------------------------------------------*/
 static void move_key ( btree_t* btree, bt_node_t* node, unsigned int index,
@@ -1689,15 +1689,15 @@ static void move_key ( btree_t* btree, bt_node_t* node, unsigned int index,
 
     d e l e t e _ k e y _ f r o m _ n o d e
 
-	@brief Delete the key at the specified position in the specified node.
+    @brief Delete the key at the specified position in the specified node.
 
-	This function will delete the key at the specified position in the
+    This function will delete the key at the specified position in the
     specified node.
 
-	@param[in] btree - The btree to operate on
-	@param[in] nodePosition - The node and index to operate on
+    @param[in] btree - The btree to operate on
+    @param[in] nodePosition - The node and index to operate on
 
-	@return Status code
+    @return Status code
 
 -----------------------------------------------------------------------------*/
 static int delete_key_from_node ( btree_t* btree, nodePosition* nodePosition )
@@ -2363,17 +2363,17 @@ void* btree_search ( btree_t* btree, void* key )
 
     b t r e e _ g e t _ m a x
 
-	@brief Get the maximum user data value in the btree.
+    @brief Get the maximum user data value in the btree.
 
-	This function will return a pointer to the user data record contained in
+    This function will return a pointer to the user data record contained in
     the largest value in the btree.  The "largest" is defined according to
     the user supplied comparison function.
 
     If the btree is empty, a null pointer will be returned.
 
-	@param[in] btree - The address of the btree to search
+    @param[in] btree - The address of the btree to search
 
-	@return The address of the maximum value in the btree.
+    @return The address of the maximum value in the btree.
 
 -----------------------------------------------------------------------------*/
 void* btree_get_max ( btree_t* btree )
@@ -2411,17 +2411,17 @@ void* btree_get_max ( btree_t* btree )
 
     b t r e e _ g e t _ m i n
 
-	@brief Get the minimum user data value in the btree.
+    @brief Get the minimum user data value in the btree.
 
-	This function will return a pointer to the user data record contained in
+    This function will return a pointer to the user data record contained in
     the smallest value in the btree.  The "smallest" is defined according to
     the user supplied comparison function.
 
     If the btree is empty, a null pointer will be returned.
 
-	@param[in] btree - The address of the btree to search
+    @param[in] btree - The address of the btree to search
 
-	@return The address of the minimum value in the btree.
+    @return The address of the minimum value in the btree.
 
 -----------------------------------------------------------------------------*/
 void* btree_get_min ( btree_t* btree )
@@ -2564,21 +2564,21 @@ void btree_traverse ( btree_t* btree, traverseFunc traverseCB )
 
     B t r e e   I t e r a t i o n   F u n c t i o n s
 
-	This section contains the implementation of the btree iterator functions.
+    This section contains the implementation of the btree iterator functions.
 
-	Example usage (assuming the btree is populated with "userData" records):
+    Example usage (assuming the btree is populated with "userData" records):
 
-		userData record = { 12, "" };
+    userData record = { 12, "" };
 
-		btree_iter iter = btree_find ( &record );
+    btree_iter iter = btree_find ( &record );
 
-		while ( ! btree_iter_at_end ( iter ) )
-		{
-            userData* returnedData = btree_iter_data ( iter );
-			...
-			btree_iter_next ( iter );
-		}
-		btree_iter_cleanup ( iter );
+    while ( ! btree_iter_at_end ( iter ) )
+    {
+        userData* returnedData = btree_iter_data ( iter );
+        ...
+        btree_iter_next ( iter );
+    }
+    btree_iter_cleanup ( iter );
 
     The above example will find all of the records in the btree beginning with
     { 12, "" } to the end of the btree.
@@ -2590,20 +2590,20 @@ void btree_traverse ( btree_t* btree, traverseFunc traverseCB )
 
     b t r e e _ i t e r a t o r _ n e w
 
-	@brief Allocate and initialize a new iterator object.
+    @brief Allocate and initialize a new iterator object.
 
-	This function will allocate memory for a new iterator object and
+    This function will allocate memory for a new iterator object and
     initialize the fields in that object appropriately.
 
     Note: The memory for this iterator is allocated with malloc rather than
     the shared memory allocator because it will live in the user's address
     space and is never seen by another process.
 
-	@param[in] btree - The address of the btree object to be operated on.
-	@param[in] key - The address of the user's data object to be found in the
+    @param[in] btree - The address of the btree object to be operated on.
+    @param[in] key - The address of the user's data object to be found in the
                      tree.
 
-	@return The btree_iter object
+    @return The btree_iter object
 
 -----------------------------------------------------------------------------*/
 static btree_iter btree_iterator_new ( btree_t* btree, void* key )
@@ -2637,9 +2637,9 @@ static btree_iter btree_iterator_new ( btree_t* btree, void* key )
 
 /*!----------------------------------------------------------------------------
 
-	b t r e e _ f i n d
+    b t r e e _ f i n d
 
-	@brief Position an iterator at the specified key location.
+    @brief Position an iterator at the specified key location.
 
     The btree_find function is similar to the btree_search function except
     that it will find the smallest key that is greater than or equal to the
@@ -2657,11 +2657,11 @@ static btree_iter btree_iterator_new ( btree_t* btree, void* key )
     with it by calling the btree_iter_cleanup function.  If this is not done,
     there will be a memory leak in the user's program.
 
-	@param[in] btree - The address of the btree object to be operated on.
-	@param[in] key - The address of the user's data object to be found in the
+    @param[in] btree - The address of the btree object to be operated on.
+    @param[in] key - The address of the user's data object to be found in the
                      tree.
 
-	@return A btree_iter object
+    @return A btree_iter object
 
 -----------------------------------------------------------------------------*/
 btree_iter btree_find ( btree_t* btree, void* key )
@@ -2895,9 +2895,9 @@ findExit:
 
 /*!----------------------------------------------------------------------------
 
-	b t r e e _ r f i n d
+    b t r e e _ r f i n d
 
-	@brief Position an iterator at the specified key location.
+    @brief Position an iterator at the specified key location.
 
     The btree_rfind function is similar to the btree_search function except
     that it will find the largest key that is less than or equal to the
@@ -2915,11 +2915,11 @@ findExit:
     with it by calling the btree_iter_cleanup function.  If this is not done,
     there will be a memory leak in the user's program.
 
-	@param[in] btree - The address of the btree object to be operated on.
-	@param[in] key - The address of the user's data object to be found in the
+    @param[in] btree - The address of the btree object to be operated on.
+    @param[in] key - The address of the user's data object to be found in the
                      tree.
 
-	@return A btree_iter object
+    @return A btree_iter object
 
 -----------------------------------------------------------------------------*/
 btree_iter btree_rfind ( btree_t* btree, void* key )
@@ -3160,9 +3160,9 @@ rfindExit:
 
     b t r e e _ i t e r _ b e g i n
 
-	@brief Create an iterator positioned at the beginning of the btree.
+    @brief Create an iterator positioned at the beginning of the btree.
 
-	This function will find the smallest record currently defined in the
+    This function will find the smallest record currently defined in the
     specified btree and return an iterator to that record.  If the btree is
     empty, an iterator will be returned but it will be empty.  This iterator
     can be compared to the iter->end() iterator to determine if it empty.
@@ -3170,9 +3170,9 @@ rfindExit:
     This function will return a new iterator object which the user MUST
     destroy (via btree_iter_cleanup()) when he is finished with it.
 
-	@param[in] btree - The address of the btree object to be operated on.
+    @param[in] btree - The address of the btree object to be operated on.
 
-	@return A btree_iter object
+    @return A btree_iter object
 
 -----------------------------------------------------------------------------*/
 btree_iter btree_iter_begin ( btree_t* btree )
@@ -3246,17 +3246,17 @@ beginExit:
 
     b t r e e _ i t e r _ e n d
 
-	@brief Create an iterator positioned past the last record of the btree.
+    @brief Create an iterator positioned past the last record of the btree.
 
-	This function will create a new iterator and set it to indicate that is is
+    This function will create a new iterator and set it to indicate that is is
     an "end" iterator.
 
     This function will return a new iterator object which the user MUST
     destroy (via btree_iter_cleanup()) when he is finished with it.
 
-	@param[in] btree - The address of the btree object to be operated on.
+    @param[in] btree - The address of the btree object to be operated on.
 
-	@return A btree_iter object
+    @return A btree_iter object
 
 -----------------------------------------------------------------------------*/
 btree_iter btree_iter_end ( btree_t* btree )
@@ -3323,7 +3323,7 @@ endExit:
 
     b t r e e _ i t e r _ n e x t
 
-	@brief Get the "next" position in the btree.
+    @brief Get the "next" position in the btree.
 
     This function will position the specified iterator to the next higher key
     value in the btree from the current position.
@@ -3333,9 +3333,9 @@ endExit:
     record in the btree.  Note that "next" is defined by the user's supplied
     comparison operator for this btree.
 
-	@param[in,out] iter - The iterator to be updated
+    @param[in,out] iter - The iterator to be updated
 
-	@return None
+    @return None
 
 -----------------------------------------------------------------------------*/
 void btree_iter_next ( btree_iter iter )
@@ -3619,7 +3619,7 @@ nextExit:
 
     b t r e e _ i t e r _ p r e v i o u s
 
-	@brief Get the "previous" position in the btree.
+    @brief Get the "previous" position in the btree.
 
     This function will position the specified iterator to the next lower key
     value in the btree from the current position.
@@ -3629,9 +3629,9 @@ nextExit:
     record in the btree.  Note that "next" is defined by the user's supplied
     comparison operator for this btree.
 
-	@param[in,out] iter - The iterator to be updated
+    @param[in,out] iter - The iterator to be updated
 
-	@return None
+    @return None
 
 -----------------------------------------------------------------------------*/
 void btree_iter_previous ( btree_iter iter )
@@ -3889,15 +3889,15 @@ previousExit:
 
     b t r e e _ i t e r _ c m p
 
-	@brief Compare 2 iterators.
+    @brief Compare 2 iterators.
 
-	This function will compare the data records using the user supplied
+    This function will compare the data records using the user supplied
     comparison function of the two supplied iterators.
 
-	@param[in] iter1 - The first position to be tested.
-	@param[in] iter2 - The second position to be tested.
+    @param[in] iter1 - The first position to be tested.
+    @param[in] iter2 - The second position to be tested.
 
-	@return < 0  - iter2 is greater than iter1.
+    @return < 0  - iter2 is greater than iter1.
             == 0 - The iterators are identical.
             > 0  - iter2 is less than iter1.
 
@@ -3914,9 +3914,9 @@ int btree_iter_cmp ( btree_iter iter1, btree_iter iter2 )
 
     b t r e e _ i t e r _ a t _ e n d
 
-	@brief Determine if this iterator is at the "end" condition.
+    @brief Determine if this iterator is at the "end" condition.
 
-	This function will determine if the input iterator is currently positioned
+    This function will determine if the input iterator is currently positioned
     at the "end" of the btree and return a "true" if it is.  Note that this
     can be used for the reverse iterator as well but in this case, the "end"
     condition is beyond the lowest value of the btree rather beyond the
@@ -3925,9 +3925,9 @@ int btree_iter_cmp ( btree_iter iter1, btree_iter iter2 )
     In this context, the term "at end" means "at the end of the iterator"
     rather than "at the end of the btree".
 
-	@param[in] iter - The iterator to be tested.
+    @param[in] iter - The iterator to be tested.
 
-	@return true  - The iterator is at the "end" of the btree.
+    @return true  - The iterator is at the "end" of the btree.
             false - The iterator is not at the "end" of the btree.
 
 -----------------------------------------------------------------------------*/
@@ -3941,9 +3941,9 @@ bool btree_iter_at_end ( btree_iter iter )
 
     b t r e e _ i t e r _ d a t a
 
-	@brief Return the user data pointer at the current position.
+    @brief Return the user data pointer at the current position.
 
-	This function will return the pointer to the user data structure that is
+    This function will return the pointer to the user data structure that is
     stored in the btree at the current iterator position.  The user data
     structure address is the "value" portion of the key/value pairs that are
     stored in the btree.
@@ -3952,9 +3952,9 @@ bool btree_iter_at_end ( btree_iter iter )
     using one of the positioning functions like btree_iter_find or a call to
     btree_iter_next, etc.
 
-	@param[in] iter - The current btree iterator.
+    @param[in] iter - The current btree iterator.
 
-	@return The address of the user data at the current iterator position.
+    @return The address of the user data at the current iterator position.
             NULL if the iterator has not been initialized.
 
 -----------------------------------------------------------------------------*/
@@ -3978,7 +3978,7 @@ void* btree_iter_data ( btree_iter iter )
 
     b t r e e _ i t e r _ c l e a n u p
 
-	@brief Release all resources held by an iterator.
+    @brief Release all resources held by an iterator.
 
     This function will clean up the specified iterator and release any
     resources being used by this iterator.  This function MUST be called when
@@ -3991,9 +3991,9 @@ void* btree_iter_data ( btree_iter iter )
     Note: Iterators are allocated with the system malloc function so they get
     freed with "free" rather than the shared memory deallocator.
 
-	@param[in] iter - The current btree iterator.
+    @param[in] iter - The current btree iterator.
 
-	@return None
+    @return None
 
 -----------------------------------------------------------------------------*/
 void btree_iter_cleanup ( btree_iter iter )
@@ -4028,19 +4028,19 @@ void btree_iter_cleanup ( btree_iter iter )
 
     b t r e e _ c o m p a r e _ f u n c t i o n
 
-	@brief Compare 2 user defined data structures.
+    @brief Compare 2 user defined data structures.
 
-	This function will compare 2 user defined data structures by looping
+    This function will compare 2 user defined data structures by looping
     through the defined "keys" for this btree and comparing the "offset_t"
     value at all of the specified key indices.  Logically this is "data1 -
     data2" where we compare all of the fields that make up the "key" in both
     data structures.
 
-	@param[in] btree - The address of the btree to be compared.
-	@param[in] data1 - The address of the first user structure to compare.
-	@param[in] data2 - The address of the second user structutre to compare.
+    @param[in] btree - The address of the btree to be compared.
+    @param[in] data1 - The address of the first user structure to compare.
+    @param[in] data2 - The address of the second user structutre to compare.
 
-	@return The result of comparing the two data structures.
+    @return The result of comparing the two data structures.
 
 -----------------------------------------------------------------------------*/
 static int btree_compare_function ( btree_t* btree, void* data1, void* data2 )
@@ -4138,10 +4138,10 @@ static offset_t blockId ( offset_t node )
 
 
 //
-//	Define the default function that will print the user data stored in the
-//	B-tree.  This is defined as a "weak" function so that this implementation
-//	will only be used if the user does not supply his own version of this
-//	function.
+//  Define the default function that will print the user data stored in the
+//  B-tree.  This is defined as a "weak" function so that this implementation
+//  will only be used if the user does not supply his own version of this
+//  function.
 //
 //  Note that since this function makes explicit assumptions about the format
 //  of the user data stored in the B-tree, it really should always be
@@ -4170,10 +4170,10 @@ static void printFunction ( char* leader, void* data )
 
 
 //
-//	Define the default function that will be called with a pointer to user
-//	data stored in the B-tree for each item stored in the B-tree.  This is
-//	defined as a "weak" function so that this implementation will only be used
-//	if the user does not supply his own version of this function.
+//  Define the default function that will be called with a pointer to user
+//  data stored in the B-tree for each item stored in the B-tree.  This is
+//  defined as a "weak" function so that this implementation will only be used
+//  if the user does not supply his own version of this function.
 //
 //  Note that since this function makes explicit assumptions about the format
 //  of the user data stored in the B-tree, it really should always be

--- a/core/btree.h
+++ b/core/btree.h
@@ -9,9 +9,9 @@
 
 /*!----------------------------------------------------------------------------
 
-	@file      btree.h
+    @file      btree.h
 
-	This file defines the data structures and configuration data for the
+    This file defines the data structures and configuration data for the
     shareed memory btree code.
 
     TODO: Generalize the key definition to include string types.

--- a/core/sharedMemory.c
+++ b/core/sharedMemory.c
@@ -8,11 +8,11 @@
 
 /*!----------------------------------------------------------------------------
 
-	@file sharedMemory.c
+    @file sharedMemory.c
 
-	This file contains the functions that manipulate the shared memory segment
-	data structures.  Most of the major functions defined in the VSI are
-	defined here.
+    This file contains the functions that manipulate the shared memory segment
+    data structures.  Most of the major functions defined in the VSI are
+    defined here.
 
 -----------------------------------------------------------------------------*/
 
@@ -70,7 +70,7 @@ static inline void semaphoreCleanupHandler ( void* arg )
 
 /*!-----------------------------------------------------------------------
 
-	S M _ L O C K
+    S M _ L O C K
 
     @brief Acquire the shared memory control structure lock.
 
@@ -96,7 +96,7 @@ static inline void semaphoreCleanupHandler ( void* arg )
 
 /*!-----------------------------------------------------------------------
 
-	S M _ U N L O C K
+    S M _ U N L O C K
 
     @brief Release the shared memory control structure lock.
 
@@ -115,13 +115,13 @@ static inline void semaphoreCleanupHandler ( void* arg )
 
     d e l e t e M e m o r y C h u n k
 
-	@brief Delete a chunk of memory from both indices.
+    @brief Delete a chunk of memory from both indices.
 
-	This function will delete a chunk of memory from both indices.
+    This function will delete a chunk of memory from both indices.
 
-	@param[in] - The header of the memory chunk to delete.
+    @param[in] - The header of the memory chunk to delete.
 
-	@return  0 = Success
+    @return  0 = Success
             ~0 = Failure (errno value)
 
 ------------------------------------------------------------------------*/
@@ -156,13 +156,13 @@ static int deleteMemoryChunk ( memoryChunk_t* chunk )
 
     i n s e r t M e m o r y C h u n k
 
-	@brief Insert a chunk of memory from both indices.
+    @brief Insert a chunk of memory from both indices.
 
-	This function will insert a chunk of memory from both indices.
+    This function will insert a chunk of memory from both indices.
 
-	@param[in] - The header of the memory chunk to insert
+    @param[in] - The header of the memory chunk to insert
 
-	@return  0 = Success
+    @return  0 = Success
             ~0 = Failure (errno value)
 
 ------------------------------------------------------------------------*/
@@ -197,51 +197,51 @@ static int insertMemoryChunk ( memoryChunk_t* chunk )
 
     s m _ i n i t i a l i z e
 
-	@brief Initialize the data structures in a new shared memory segment.
+    @brief Initialize the data structures in a new shared memory segment.
 
-	The specified file (referenced by the supplied file descriptor) will be
-	mapped into virtual memory and the size of the file adjusted to match the
-	desired size of the shared memory segment.
+    The specified file (referenced by the supplied file descriptor) will be
+    mapped into virtual memory and the size of the file adjusted to match the
+    desired size of the shared memory segment.
 
-	This function will set up all of the data structures in the shared memory
-	segment for use.  This function should be called after a brand new shared
-	memory segment has been created and opened on disk.  This function should
-	not be called on an existing shared memory segment that contains data as
-	all of that data will be deleted by this function.
+    This function will set up all of the data structures in the shared memory
+    segment for use.  This function should be called after a brand new shared
+    memory segment has been created and opened on disk.  This function should
+    not be called on an existing shared memory segment that contains data as
+    all of that data will be deleted by this function.
 
-	@param[in] fd - The file descriptor of the file associated with this
-			   shared memory segment.
+    @param[in] fd - The file descriptor of the file associated with this
+    shared memory segment.
 
-	@param[in] sharedMemorySegmentSize - The size of the shared memory
-			   segment in bytes.
+    @param[in] sharedMemorySegmentSize - The size of the shared memory
+    segment in bytes.
 
-	@return The new memory address of where the shared memory segment begins.
-	        On error, a null pointer is returned and errno will be set to
-			indicate the error that was encountered.
+    @return The new memory address of where the shared memory segment begins.
+            On error, a null pointer is returned and errno will be set to
+            indicate the error that was encountered.
 
 ------------------------------------------------------------------------*/
 sharedMemory_p sm_initialize ( int fd, size_t sharedMemorySegmentSize )
 {
-	int            status;
-	sharedMemory_p sharedMemory;
+    int            status;
+    sharedMemory_p sharedMemory;
 
     LOG ( "Initializing user shared memory - fd[%d], Size[%'lu]\n", fd,
           sharedMemorySegmentSize );
-	//
-	//	Map the shared memory file into virtual memory.
-	//
-	sharedMemory = mmap ( NULL, INITIAL_SHARED_MEMORY_SIZE,
-                          PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0 );
-	if ( sharedMemory == MAP_FAILED )
-	{
-		printf ( "Unable to map the user shared memory segment. errno: %u[%m].\n",
-				 errno );
-		return 0;
-	}
     //
-	//	Make the pseudo-file for the shared memory segment the size of the
-	//	shared memory segment.  Note that this will destroy any existing data
-	//	if the segment already exists.
+    //  Map the shared memory file into virtual memory.
+    //
+    sharedMemory = mmap ( NULL, INITIAL_SHARED_MEMORY_SIZE,
+                          PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0 );
+    if ( sharedMemory == MAP_FAILED )
+    {
+        printf ( "Unable to map the user shared memory segment. errno: %u[%m].\n",
+                 errno );
+        return 0;
+    }
+    //
+    //  Make the pseudo-file for the shared memory segment the size of the
+    //  shared memory segment.  Note that this will destroy any existing data
+    //  if the segment already exists.
     //
     status = ftruncate ( fd, INITIAL_SHARED_MEMORY_SIZE );
     if (status != 0)
@@ -250,11 +250,11 @@ sharedMemory_p sm_initialize ( int fd, size_t sharedMemorySegmentSize )
                  "errno: %u[%m].\n", INITIAL_SHARED_MEMORY_SIZE, errno );
         return 0;
     }
-	//
-	//	Set all of the data in this shared memory segment to zero.
-	//
-	// TODO: (void)memset ( sharedMemory, 0, sharedMemorySegmentSize );
-	(void)memset ( sharedMemory, 0xaa, sharedMemorySegmentSize );
+    //
+    //  Set all of the data in this shared memory segment to zero.
+    //
+    // TODO: (void)memset ( sharedMemory, 0, sharedMemorySegmentSize );
+    (void)memset ( sharedMemory, 0xaa, sharedMemorySegmentSize );
 
     //
     //  Initialize our global pointer to the shared memory segment.
@@ -272,11 +272,11 @@ sharedMemory_p sm_initialize ( int fd, size_t sharedMemorySegmentSize )
     sharedMemory->currentSize             = sharedMemorySegmentSize - smSize;
     sharedMemory->systemInitialized       = 0;
 
-	//
-	//	Create the mutex attribute initializer that we can use to initialize
-	//	all of the mutexes in the B-trees.
     //
-	pthread_mutexattr_t* mutexAttributes = &sharedMemory->masterMutexAttributes;
+    //  Create the mutex attribute initializer that we can use to initialize
+    //  all of the mutexes in the B-trees.
+    //
+    pthread_mutexattr_t* mutexAttributes = &sharedMemory->masterMutexAttributes;
 
     status =  pthread_mutexattr_init ( mutexAttributes );
     if ( status != 0 )
@@ -289,7 +289,7 @@ sharedMemory_p sm_initialize ( int fd, size_t sharedMemorySegmentSize )
     // Set this mutex to be a process shared mutex.
     //
     status = pthread_mutexattr_setpshared ( mutexAttributes,
-											PTHREAD_PROCESS_SHARED );
+                                            PTHREAD_PROCESS_SHARED );
     if ( status != 0 )
     {
         printf ( "Unable to set shared mutex attribute - errno: %u[%m].\n",
@@ -300,37 +300,37 @@ sharedMemory_p sm_initialize ( int fd, size_t sharedMemorySegmentSize )
     // Set this mutex to be a recursive mutex.
     //
     status = pthread_mutexattr_settype ( mutexAttributes,
-										 PTHREAD_MUTEX_RECURSIVE );
+                                         PTHREAD_MUTEX_RECURSIVE );
     if ( status != 0 )
     {
         printf ( "Unable to set recursive mutex attribute - errno: %u[%m].\n",
                  status );
         return 0;
     }
-	//
-	//	Create the condition variable initializer that we can use to
-	//	initialize all of the condition variables in the B-trees.
-	//
-	pthread_condattr_t* conditionVariableAttributes =
+    //
+    //  Create the condition variable initializer that we can use to
+    //  initialize all of the condition variables in the B-trees.
+    //
+    pthread_condattr_t* conditionVariableAttributes =
         &sharedMemory->masterCvAttributes;
 
-	status = pthread_condattr_init ( conditionVariableAttributes );
+    status = pthread_condattr_init ( conditionVariableAttributes );
 
     if ( status != 0 )
     {
         printf ( "Unable to initialize condition variable attributes - "
-			     "errno: %u[%m].\n", status );
+                 "errno: %u[%m].\n", status );
         return 0;
     }
-	//
-	//	Set this condition variable to be shared between processes.
-	//
-	status = pthread_condattr_setpshared ( conditionVariableAttributes,
-										   PTHREAD_PROCESS_SHARED );
+    //
+    //  Set this condition variable to be shared between processes.
+    //
+    status = pthread_condattr_setpshared ( conditionVariableAttributes,
+                                           PTHREAD_PROCESS_SHARED );
     if ( status != 0 )
     {
         printf ( "Unable to set shared condition variable attributes - "
-				 "errno: %u[%m].\n", status );
+                 "errno: %u[%m].\n", status );
         return 0;
     }
     //
@@ -390,10 +390,10 @@ sharedMemory_p sm_initialize ( int fd, size_t sharedMemorySegmentSize )
     dumpSM();
 #endif
 
-	//
-	//	Return the address of the shared memory segment to the caller.
-	//
-	return sharedMemory;
+    //
+    //  Return the address of the shared memory segment to the caller.
+    //
+    return sharedMemory;
 }
 
 
@@ -402,51 +402,51 @@ sharedMemory_p sm_initialize ( int fd, size_t sharedMemorySegmentSize )
 TODO: FIX!
     s m _ i n i t i a l i z e _ s y s
 
-	@brief Initialize the data structures in a new shared memory segment.
+    @brief Initialize the data structures in a new shared memory segment.
 
-	The specified file (referenced by the supplied file descriptor) will be
-	mapped into virtual memory and the size of the file adjusted to match the
-	desired size of the shared memory segment.
+    The specified file (referenced by the supplied file descriptor) will be
+    mapped into virtual memory and the size of the file adjusted to match the
+    desired size of the shared memory segment.
 
-	This function will set up all of the data structures in the shared memory
-	segment for use.  This function should be called after a brand new shared
-	memory segment has been created and opened on disk.  This function should
-	not be called on an existing shared memory segment that contains data as
-	all of that data will be deleted by this function.
+    This function will set up all of the data structures in the shared memory
+    segment for use.  This function should be called after a brand new shared
+    memory segment has been created and opened on disk.  This function should
+    not be called on an existing shared memory segment that contains data as
+    all of that data will be deleted by this function.
 
-	@param[in] fd - The file descriptor of the file associated with this
-			   shared memory segment.
+    @param[in] fd - The file descriptor of the file associated with this
+                    shared memory segment.
 
-	@param[in] sharedMemorySegmentSize - The size of the shared memory
-			   segment in bytes.
+    @param[in] sharedMemorySegmentSize - The size of the shared segment in
+               bytes.
 
-	@return The new memory address of where the shared memory segment begins.
-	        On error, a null pointer is returned and errno will be set to
-			indicate the error that was encountered.
+    @return The new memory address of where the shared memory segment begins.
+            On error, a null pointer is returned and errno will be set to
+            indicate the error that was encountered.
 
 ------------------------------------------------------------------------*/
 sysMemory_p sm_initialize_sys ( int fd, size_t sharedMemorySegmentSize )
 {
-	int         status;
-	sysMemory_p sharedMemory;
+    int         status;
+    sysMemory_p sharedMemory;
 
     LOG ( "Initializing system shared memory - fd[%d], Size[%'lu]\n", fd,
           sharedMemorySegmentSize );
-	//
-	//	Map the shared memory file into virtual memory.
-	//
-	sharedMemory = mmap ( NULL, SYS_INITIAL_SHARED_MEMORY_SIZE,
-                          PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0 );
-	if ( sharedMemory == MAP_FAILED )
-	{
-		printf ( "Unable to map the system shared memory segment. errno: %u[%m].\n",
-				 errno );
-		return 0;
-	}
     //
-	//	Make the pseudo-file for the shared memory segment the size of the
-	//	shared memory segment.  Note that this will destroy any existing data
-	//	if the segment already exists.
+    //  Map the shared memory file into virtual memory.
+    //
+    sharedMemory = mmap ( NULL, SYS_INITIAL_SHARED_MEMORY_SIZE,
+                          PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0 );
+    if ( sharedMemory == MAP_FAILED )
+    {
+        printf ( "Unable to map the system shared memory segment. errno: %u[%m].\n",
+                 errno );
+        return 0;
+    }
+    //
+    //  Make the pseudo-file for the shared memory segment the size of the
+    //  shared memory segment.  Note that this will destroy any existing data
+    //  if the segment already exists.
     //
     status = ftruncate ( fd, SYS_INITIAL_SHARED_MEMORY_SIZE );
     if (status != 0)
@@ -456,11 +456,11 @@ sysMemory_p sm_initialize_sys ( int fd, size_t sharedMemorySegmentSize )
                   errno );
         return 0;
     }
-	//
-	//	Set all of the data in this shared memory segment to zero.
-	//
-	// TODO: (void)memset ( sharedMemory, 0, sharedMemorySegmentSize );
-	(void)memset ( sharedMemory, 0xbb, sharedMemorySegmentSize );
+    //
+    //  Set all of the data in this shared memory segment to zero.
+    //
+    // TODO: (void)memset ( sharedMemory, 0, sharedMemorySegmentSize );
+    (void)memset ( sharedMemory, 0xbb, sharedMemorySegmentSize );
 
     //
     //  Initialize our global pointer to the shared memory segment.
@@ -478,11 +478,11 @@ sysMemory_p sm_initialize_sys ( int fd, size_t sharedMemorySegmentSize )
     sharedMemory->currentSize             = sharedMemorySegmentSize - sysSize;
     sharedMemory->systemInitialized       = 0;
 
-	//
-	//	Create the mutex attribute initializer that we can use to initialize
-	//	all of the mutexes in the B-trees.
     //
-	pthread_mutexattr_t* mutexAttributes = &sharedMemory->masterMutexAttributes;
+    //  Create the mutex attribute initializer that we can use to initialize
+    //  all of the mutexes in the B-trees.
+    //
+    pthread_mutexattr_t* mutexAttributes = &sharedMemory->masterMutexAttributes;
 
     status =  pthread_mutexattr_init ( mutexAttributes );
     if ( status != 0 )
@@ -495,7 +495,7 @@ sysMemory_p sm_initialize_sys ( int fd, size_t sharedMemorySegmentSize )
     // Set this mutex to be a process shared mutex.
     //
     status = pthread_mutexattr_setpshared ( mutexAttributes,
-											PTHREAD_PROCESS_SHARED );
+                                            PTHREAD_PROCESS_SHARED );
     if ( status != 0 )
     {
         printf ( "Unable to set system shared mutex attribute - errno: %u[%m].\n",
@@ -506,7 +506,7 @@ sysMemory_p sm_initialize_sys ( int fd, size_t sharedMemorySegmentSize )
     // Set this mutex to be a recursive mutex.
     //
     status = pthread_mutexattr_settype ( mutexAttributes,
-										 PTHREAD_MUTEX_RECURSIVE );
+                                         PTHREAD_MUTEX_RECURSIVE );
     if ( status != 0 )
     {
         printf ( "Unable to set system recursive mutex attribute - errno: %u[%m].\n",
@@ -530,24 +530,24 @@ sysMemory_p sm_initialize_sys ( int fd, size_t sharedMemorySegmentSize )
     //  We do this by creating a singly linked list of blocks using the blocks
     //  themselves containing the offset to the next block.
     //
-	//  Now compute the size of each node in the system B-trees...
+    //  Now compute the size of each node in the system B-trees...
     //
     //  If the user specified an even number of records, increment it to be an
     //  odd number.  The btree algorithm here only operates correctly if the
     //  record count is odd.
-	//
+    //
     unsigned int maxRecordsPerNode = SYS_RECORD_COUNT;
 
-	if ( ( maxRecordsPerNode & 1 ) == 0 )
-	{
-		maxRecordsPerNode++;
-	}
-	//
-	//  Compute the node size as the btree node header size plus the size of
-	//  the record offset area plus the link offfset area.
-	//
+    if ( ( maxRecordsPerNode & 1 ) == 0 )
+    {
+        maxRecordsPerNode++;
+    }
+    //
+    //  Compute the node size as the btree node header size plus the size of
+    //  the record offset area plus the link offfset area.
+    //
     unsigned int nodeSize = sN + ( maxRecordsPerNode * sO ) +
-					        ( ( maxRecordsPerNode + 1 ) * sO );
+                            ( ( maxRecordsPerNode + 1 ) * sO );
     //
     //  Round up the node size to the next multiple of 8 bytes to maintain
     //  long int alignment in the structures.
@@ -649,10 +649,10 @@ sysMemory_p sm_initialize_sys ( int fd, size_t sharedMemorySegmentSize )
     //
     LOG ( "\n===== System shared memory is Initialized at %p =====\n\n",
           sharedMemory );
-	//
-	//	Return the address of the shared memory segment to the caller.
-	//
-	return sharedMemory;
+    //
+    //  Return the address of the shared memory segment to the caller.
+    //
+    return sharedMemory;
 }
 
 
@@ -660,7 +660,7 @@ sysMemory_p sm_initialize_sys ( int fd, size_t sharedMemorySegmentSize )
 
     s m _ m a l l o c
 
-	@brief Allocate a chunk of shared memory for a user.
+    @brief Allocate a chunk of shared memory for a user.
 
     This function will allocate a chunk of shared memory of the specified size
     (in bytes).  If no memory is available of the specified size, a NULL
@@ -670,9 +670,9 @@ sysMemory_p sm_initialize_sys ( int fd, size_t sharedMemorySegmentSize )
     This function operates identically to the system "malloc" function and can
     be used the same way.
 
-	@param[in] size - The size in bytes of the memory desired.
+    @param[in] size - The size in bytes of the memory desired.
 
-	@return The address of the allocated memory chunk.
+    @return The address of the allocated memory chunk.
             NULL if the request could not be honored.
 
 -----------------------------------------------------------------------------*/
@@ -850,15 +850,15 @@ mallocEnd:
 
     s m _ m a l l o c _ s y s
 
-	@brief
+    @brief
 
-	This function will
+    This function will
 
-	@param[in]
-	@param[out]
-	@param[in,out]
+    @param[in]
+    @param[out]
+    @param[in,out]
 
-	@return None
+    @return None
 
 -----------------------------------------------------------------------------*/
 void* sm_malloc_sys ( size_t size )
@@ -889,7 +889,7 @@ void* sm_malloc_sys ( size_t size )
 
     s m _ f r e e
 
-	@brief Deallocate a chunk of shared memory.
+    @brief Deallocate a chunk of shared memory.
 
     This function will deallocate the specified chunk of shared memory
     supplied by the caller.  If the supplied chunk of memory is not a valid
@@ -905,9 +905,9 @@ void* sm_malloc_sys ( size_t size )
     This function operates identically to the system "free" function and can
     be used the same way.
 
-	@param[in] allocatedMemory - The address of the chunk of shared memory to free.
+    @param[in] allocatedMemory - The address of the chunk of shared memory to free.
 
-	@return None
+    @return None
 
 -----------------------------------------------------------------------------*/
 void sm_free ( void* userMemory )
@@ -1071,15 +1071,15 @@ void sm_free ( void* userMemory )
 
     s m _ f r e e _ s y s
 
-	@brief
+    @brief
 
-	This function will
+    This function will
 
-	@param[in]
-	@param[out]
-	@param[in,out]
+    @param[in]
+    @param[out]
+    @param[in,out]
 
-	@return None
+    @return None
 
 ------------------------------------------------------------------------*/
 void sm_free_sys ( void* memoryBlock )
@@ -1098,7 +1098,7 @@ void sm_free_sys ( void* memoryBlock )
 
     M e m o r y   A l l o c a t i o n   D e b u g   F u n c t i o n s
 
-	The following functions are designed for debugging purposes and will
+    The following functions are designed for debugging purposes and will
     normally not be included in production builds.
 
 -----------------------------------------------------------------------------*/
@@ -1217,17 +1217,17 @@ void dumpSM ( void )
 
     f i n d S i g n a l L i s t
 
-	@brief Find the the signal list for a domain and key value.
+    @brief Find the the signal list for a domain and key value.
 
-	This function will search the signals btree for a match to the domain and
+    This function will search the signals btree for a match to the domain and
     id value supplied.  If a match is found, the address of the signal list
     control block will be returned to the caller.  If no match is found, a
     null pointer will be returned.
 
-	@param[in] - domain - The domain of the signal list to find
-	@param[in] - key - The id of the signal list to find
+    @param[in] - domain - The domain of the signal list to find
+    @param[in] - key - The id of the signal list to find
 
-	@return If successful, the address of the signal list control block
+    @return If successful, the address of the signal list control block
             If not found, a NULL
 
 -----------------------------------------------------------------------------*/
@@ -1268,7 +1268,7 @@ signalList_t* findSignalList ( domain_t domain, vsiKey_t key )
     @param[in] body - The address of the body of the new message.
 
     @return 0 if successful
-		    Otherwise the error code
+            Otherwise the error code
 
 ------------------------------------------------------------------------*/
 int sm_insert ( domain_t domain, vsiKey_t key, unsigned long newMessageSize,
@@ -1453,24 +1453,24 @@ insertExit:
 
     s m _ r e m o v e S i g n a l
 
-	@brief Remove the oldest signal from the signal list.
+    @brief Remove the oldest signal from the signal list.
 
     This function will remove the signal at the beginning of the specified
     signal list.
 
-	WARNING: This function assumes that the signal list mutex has been
-	acquired before this function is called.
+    WARNING: This function assumes that the signal list mutex has been
+    acquired before this function is called.
 
-	@param[in] signalList - The address of the signal list to operate on.
+    @param[in] signalList - The address of the signal list to operate on.
 
-	@return 0 - Message successfully removed.
+    @return 0 - Message successfully removed.
 
 ------------------------------------------------------------------------*/
 int sm_removeSignal ( signalList_p signalList )
 {
-	signalData_t* signal;
+    signalData_t* signal;
 
-	LOG ( "%'lu  Removing signal...\n", getIntervalTime() );
+    LOG ( "%'lu  Removing signal...\n", getIntervalTime() );
 
     //
     //  If this signal list is empty, just return without doing anything.
@@ -1479,15 +1479,15 @@ int sm_removeSignal ( signalList_p signalList )
     {
         return 0;
     }
-	//
-	//	Grab the first signal on the given signalList control block.
-	//
-	signal = toAddress ( signalList->head );
+    //
+    //  Grab the first signal on the given signalList control block.
+    //
+    signal = toAddress ( signalList->head );
 
     //
-    //	If there is only one message in the current list then the head and
-    //	tail offsets will be the same and we should just set both of them to
-    //	the "empty" list state.
+    //  If there is only one message in the current list then the head and
+    //  tail offsets will be the same and we should just set both of them to
+    //  the "empty" list state.
     //
     if ( signalList->currentSignalCount == 1 )
     {
@@ -1495,35 +1495,35 @@ int sm_removeSignal ( signalList_p signalList )
         signalList->tail = END_OF_LIST_MARKER;
     }
     //
-    //	Otherwise, just make the head offset be the offset of the next signal
-    //	after the one we are removing.
+    //  Otherwise, just make the head offset be the offset of the next signal
+    //  after the one we are removing.
     //
     else
     {
         signalList->head = signal->nextMessageOffset;
     }
-	//
-	//	Decrement the count of the number of signals in this list and the
-    //	total amount of space occupied by those signals.
-	//
-	--signalList->currentSignalCount;
+    //
+    //  Decrement the count of the number of signals in this list and the
+    //  total amount of space occupied by those signals.
+    //
+    --signalList->currentSignalCount;
     signalList->totalSignalSize -= signal->messageSize;
 
-	//
-	//	Decrement the count of the number of signals in the list within the
-	//	semaphore.
-	//
-	--signalList->semaphore.messageCount;
+    //
+    //  Decrement the count of the number of signals in the list within the
+    //  semaphore.
+    //
+    --signalList->semaphore.messageCount;
 
     //
     //  Free up the shared memory occupied by this signal data structure.
     //
     sm_free ( signal );
 
-	//
-	//	Return a good completion code to the caller.
-	//
-	return 0;
+    //
+    //  Return a good completion code to the caller.
+    //
+    return 0;
 }
 
 
@@ -1907,7 +1907,7 @@ int sm_flush_signal ( domain_t domain, vsiKey_t key )
 
     S i g n a l   D e b u g   F u n c t i o n s
 
-	The following functions are designed for debugging purposes and will
+    The following functions are designed for debugging purposes and will
     normally not be included in production builds.
 
 -----------------------------------------------------------------------------*/

--- a/core/sharedMemory.h
+++ b/core/sharedMemory.h
@@ -11,24 +11,24 @@
     @file sharedMemory.h
 
     This file contains the declarations of the shared memory segment constants
-	and data structures and should be included in all files that need to
-	operate on the shared memory segment structures.
+    and data structures and should be included in all files that need to
+    operate on the shared memory segment structures.
 
-	The beginning of this file contains some constants that can be used to
-	customize various characteristics of the data store.
+    The beginning of this file contains some constants that can be used to
+    customize various characteristics of the data store.
 
-	WARNING!!!: All references (and pointers) to data in the shared memory
-	segment are performed by using the byte index into the shared memory
-	segment.  All of these references need to be relocatable references so
-	this will work in multiple processes that have their shared memory
-	segments mapped to different base addresses.
+    WARNING!!!: All references (and pointers) to data in the shared memory
+    segment are performed by using the byte index into the shared memory
+    segment.  All of these references need to be relocatable references so
+    this will work in multiple processes that have their shared memory
+    segments mapped to different base addresses.
 
-	Some of the constructs and functions defined here are designed to make
-	porting to C++ as easy as possible so there are things here that look
-	decidedly like C++ member functions for example.  There is no need for
-	inheritance so that's not present (along with it's associated virtual
-	function table) but I do wish that I could use function overloading in
-	several places... Oh well!
+    Some of the constructs and functions defined here are designed to make
+    porting to C++ as easy as possible so there are things here that look
+    decidedly like C++ member functions for example.  There is no need for
+    inheritance so that's not present (along with it's associated virtual
+    function table) but I do wish that I could use function overloading in
+    several places... Oh well!
 
 -----------------------------------------------------------------------------*/
 
@@ -74,7 +74,7 @@
 
 
 //
-//	Define the global constants and variables.
+//  Define the global constants and variables.
 //
 //  Note that the shared memory size will always be allocated (by the kernel)
 //  in units of whole memory pages.  Most modern system have 4K byte memory
@@ -149,8 +149,8 @@ extern struct sysMemory_t*    sysControl;
 
 
 //
-//	Define the type to be used for all of the offset references inside the
-//	shared memory segment.
+//  Define the type to be used for all of the offset references inside the
+//  shared memory segment.
 //
 typedef unsigned long offset_t;
 typedef unsigned long domain_t;
@@ -161,7 +161,7 @@ typedef unsigned long vsiKey_t;
 
     m e m o r y C h u n k _ t
 
-	@brief Define the shared memory memory region control structure.
+    @brief Define the shared memory memory region control structure.
 
     Define the data structure that will be used to keep track of chunks of
     memory in the B-trees.  This data structure is prepended to each memory
@@ -212,7 +212,7 @@ static const unsigned long SPLIT_THRESHOLD   = 16;
 
     s i g n a l L i s t _ t
 
-	@brief Define the structure of each signal list structure.
+    @brief Define the structure of each signal list structure.
 
     This function will define the structure of each signal list in the system.
     A signal list is a list of signals that all have the same domain and key
@@ -231,22 +231,22 @@ typedef struct signalList_t
     //  Define the signal domain and ID values for all of the signals that
     //  will be stored in this signal list.
     //
-	domain_t domain;
-	vsiKey_t key;
+    domain_t domain;
+    vsiKey_t key;
 
-	//
-	//	Define the variables that will be used to keep track of the linked
-	//	list data within each signal list.
-	//
-	//	Note: The "head" is the offset to the first available message in the
-	//	current list and the "tail" is the offset to the last available
-	//	message in the list (i.e. NOT the next available message slot).  This
-	//	is required because we need to be able to update the "next" pointer in
-	//	the last message whenever we append a new message to the list and we
-	//	can't back up in the list (it's a singly linked list).
-	//
-	offset_t head;
-	offset_t tail;
+    //
+    //  Define the variables that will be used to keep track of the linked
+    //  list data within each signal list.
+    //
+    //  Note: The "head" is the offset to the first available message in the
+    //  current list and the "tail" is the offset to the last available
+    //  message in the list (i.e. NOT the next available message slot).  This
+    //  is required because we need to be able to update the "next" pointer in
+    //  the last message whenever we append a new message to the list and we
+    //  can't back up in the list (it's a singly linked list).
+    //
+    offset_t head;
+    offset_t tail;
 
     //
     //  The following fields are just for informational use.  We probably
@@ -254,18 +254,18 @@ typedef struct signalList_t
     //  the sum of all of the message fields in this list but this does not
     //  count the signal data header structure sizes in the sum.
     //
-	unsigned long currentSignalCount;
-	unsigned long totalSignalSize;
+    unsigned long currentSignalCount;
+    unsigned long totalSignalSize;
 
-	//
-    //	Define the semaphore that will be used to manage the processes waiting
-    //	for messages on the message queue.  Each message that is received will
-    //	increment the semaphore and each "wait" that is executed will
-    //	decrement the semaphore.
-	//
+    //
+    //  Define the semaphore that will be used to manage the processes waiting
+    //  for messages on the message queue.  Each message that is received will
+    //  increment the semaphore and each "wait" that is executed will
+    //  decrement the semaphore.
+    //
     semaphore_t semaphore;
 
-}	signalList_t, *signalList_p;
+}   signalList_t, *signalList_p;
 
 #define SIGNAL_LIST_SIZE   ( sizeof(signalList_t) )
 #define END_OF_LIST_MARKER ( 0 )
@@ -274,7 +274,7 @@ typedef struct signalList_t
 
     s i g n a l D a t a _ t
 TODO: REDO!
-	@brief Define the structure of the header of each signal data item.
+    @brief Define the structure of the header of each signal data item.
 
     This message header contains all of the information required to manage a
     message in the shared memory structures.  This "shared message" structure
@@ -324,18 +324,18 @@ TODO: REDO!
 ------------------------------------------------------------------------*/
 typedef struct signalData_t
 {
-	offset_t nextMessageOffset;
-	offset_t messageSize;
-	char     data[0];
+    offset_t nextMessageOffset;
+    offset_t messageSize;
+    char     data[0];
 
 }   signalData_t, *signalData_p;
 
 //
-//	Define the size of the shared message header structure.  This value needs
-//	to be taken into account when the total size of a message is computed.
-//	The "messageSize" field in this header is the size of the "data" field at
-//	the end of the structure so to get the total size of a structure, we must
-//	use:
+//  Define the size of the shared message header structure.  This value needs
+//  to be taken into account when the total size of a message is computed.
+//  The "messageSize" field in this header is the size of the "data" field at
+//  the end of the structure so to get the total size of a structure, we must
+//  use:
 //
 //    totalMessageSize = messagePtr->messageSize + SIGNAL_DATA_HEADER_SIZE;
 //
@@ -344,11 +344,11 @@ typedef struct signalData_t
 
 /*!---------------------------------------------------------------------------
 
-	s h a r e d M e m o r y _ t
+    s h a r e d M e m o r y _ t
 
-	@brief	Define the structure of the shared memory segment.
+    @brief  Define the structure of the shared memory segment.
 
-	This data structure defines the base shared memory segment and is used as
+    This data structure defines the base shared memory segment and is used as
     the shared memory control structure by all of the shared memory functions.
 
 ----------------------------------------------------------------------------*/
@@ -381,7 +381,7 @@ typedef struct sharedMemory_t
     //  Create the condition variable attribute initializer that we can use to
     //  initialize all of the condition variables in the B-trees.
     //
-	pthread_condattr_t masterCvAttributes;
+    pthread_condattr_t masterCvAttributes;
 
     //
     //  Define the mutex that will be used to control access to the shared
@@ -409,10 +409,10 @@ typedef struct sharedMemory_t
     //  This variable is the base time that gets set when the process first
     //  starts.  All other times are computed relative to this value.
     //
-	unsigned long globalTime;
+    unsigned long globalTime;
 #endif
 
-}	sharedMemory_t, *sharedMemory_p;
+}   sharedMemory_t, *sharedMemory_p;
 
 
 /*!---------------------------------------------------------------------------
@@ -452,7 +452,7 @@ typedef struct sysMemory_t
     //  Create the condition variable attribute initializer that we can use to
     //  initialize all of the condition variables in the B-trees.
     //
-	pthread_condattr_t masterCvAttributes;
+    pthread_condattr_t masterCvAttributes;
 
     //
     //  Define the mutex that will be used to control access to the shared
@@ -474,20 +474,20 @@ typedef struct sysMemory_t
 
 /*!-----------------------------------------------------------------------
 
-	S i g n a l   L i s t   m e m b e r   f u n c t i o n s
+    S i g n a l   L i s t   m e m b e r   f u n c t i o n s
 
 ------------------------------------------------------------------------*/
 //
-//	Return the address of a message from the specified signal list.
+//  Return the address of a message from the specified signal list.
 //
-//	This function will return the actual pointer into the shared memory
-//	segment that corresponds to the location of the "offset" within the
-//	specified signal list.  These pointers are necessary when we want to
-//	actually read and write data into the messages being stored.
+//  This function will return the actual pointer into the shared memory
+//  segment that corresponds to the location of the "offset" within the
+//  specified signal list.  These pointers are necessary when we want to
+//  actually read and write data into the messages being stored.
 //
 inline static void* toAddress ( offset_t offset )
 {
-	return (void*)( (void*)smControl + offset );
+    return (void*)( (void*)smControl + offset );
 }
 
 
@@ -503,7 +503,7 @@ inline static offset_t toOffset ( void* address )
 
 ------------------------------------------------------------------------*/
 //
-//	Initialize the shared memory segments.
+//  Initialize the shared memory segments.
 //
 //  These functions will take a newly created shared memory segment file
 //  descriptor and size, map the file into memory, and initialize all of the
@@ -545,22 +545,22 @@ int sm_insert ( domain_t domain, vsiKey_t key, unsigned long newMessageSize,
                 void* body );
 
 //
-//	Remove the first message from the given signal list.
+//  Remove the first message from the given signal list.
 //
 //  This function will remove the signal at the beginning of the specified
 //  signal list.
 //
-//	WARNING: This function assumes that the signal list mutex has been
-//	acquired before this function is called.
+//  WARNING: This function assumes that the signal list mutex has been
+//  acquired before this function is called.
 //
 int sm_removeSignal ( signalList_p signalList );
 
 
 //
-//	Fetch the oldest available record from the user data store.
+//  Fetch the oldest available record from the user data store.
 //
-//	This function will find the oldest record in the data store with the
-//	specified domain and key and return a copy of it to the caller.
+//  This function will find the oldest record in the data store with the
+//  specified domain and key and return a copy of it to the caller.
 //
 //  Note that this function will remove the record that was found from the
 //  data store.
@@ -569,10 +569,10 @@ int sm_fetch ( domain_t domain, vsiKey_t key, unsigned long* messageSize,
                void* body, bool dontWait );
 
 //
-//	Fetch the newest available record from the user data store.
+//  Fetch the newest available record from the user data store.
 //
-//	This function will find the newest record in the data store with the
-//	specified domain and key and return a copy of it to the caller.
+//  This function will find the newest record in the data store with the
+//  specified domain and key and return a copy of it to the caller.
 //
 //  Note that this function will NOT remove the record that was found from the
 //  data store.
@@ -598,7 +598,7 @@ void dumpFreeByOffset ( void );
 void dumpAllSignals   ( int maxSignals );
 
 
-#endif	// End of #ifndef SHARED_MEMORY_H
+#endif  // End of #ifndef SHARED_MEMORY_H
 
 /*! @} */
 

--- a/core/sharedMemoryLocks.c
+++ b/core/sharedMemoryLocks.c
@@ -8,10 +8,10 @@
 
 /*!----------------------------------------------------------------------------
 
-	@file      semaphore.c
+    @file      semaphore.c
 
-	This file contains the definitions of all of the semaphore objects and
-	member functions.
+    This file contains the definitions of all of the semaphore objects and
+    member functions.
 
 -----------------------------------------------------------------------------*/
 
@@ -35,50 +35,50 @@
 
 /*!-----------------------------------------------------------------------
 
-	s e m a p h o r e P o s t
+    s e m a p h o r e P o s t
 
-	@brief Perform a "post" operation on a semaphore.
+    @brief Perform a "post" operation on a semaphore.
 
-	This function will perform a "post" operation on a semaphore object
-	(similar to a "signal" on a mutex).  This operation will increment the
-	semaphore's count value and if there are any processes waiting on this
-	semahore, one (or possibly more) of them will be released and allowed to
-	run.  Under normal conditions, only one waiting process will be released
-	when this signal occurs but there is a very small window in which more
-	than one could be released.  This is not a problem - See the man page for
-	pthread_cond_signal.
+    This function will perform a "post" operation on a semaphore object
+    (similar to a "signal" on a mutex).  This operation will increment the
+    semaphore's count value and if there are any processes waiting on this
+    semahore, one (or possibly more) of them will be released and allowed to
+    run.  Under normal conditions, only one waiting process will be released
+    when this signal occurs but there is a very small window in which more
+    than one could be released.  This is not a problem - See the man page for
+    pthread_cond_signal.
 
-	That this code assumes that the semaphore object to be operated on already
-	exists and has been mapped into this process's shared memory segment.  The
-	semaphore must already have been initialized as well.
+    That this code assumes that the semaphore object to be operated on already
+    exists and has been mapped into this process's shared memory segment.  The
+    semaphore must already have been initialized as well.
 
-	@param[in] semaphore - The address of the semaphore object to operate on.
+    @param[in] semaphore - The address of the semaphore object to operate on.
 
 ------------------------------------------------------------------------*/
 void semaphorePost ( semaphore_p semaphore )
 {
-	int status;
+    int status;
 
-	//
-	//	If the semaphore count is at 0 then someone may be currently waiting
-	//	on this semaphore so just signal the condition variable to indicate
-	//	that the resource is available and release the process(s) that are
-	//	waiting.
-	//
-	LOG ( "%'lu Before semaphore broadcast of %p:\n", getIntervalTime(),
+    //
+    //  If the semaphore count is at 0 then someone may be currently waiting
+    //  on this semaphore so just signal the condition variable to indicate
+    //  that the resource is available and release the process(s) that are
+    //  waiting.
+    //
+    LOG ( "%'lu Before semaphore broadcast of %p:\n", getIntervalTime(),
           semaphore );
-	SEM_DUMP ( semaphore );
+    SEM_DUMP ( semaphore );
 
-	status = pthread_cond_broadcast ( &semaphore->conditionVariable );
-	if ( status != 0 )
-	{
-		printf ( "Unable to broadcast to condition variable - "
-				 "errno: %u[%s].\n", status, strerror(status) );
-	}
+    status = pthread_cond_broadcast ( &semaphore->conditionVariable );
+    if ( status != 0 )
+    {
+        printf ( "Unable to broadcast to condition variable - "
+                 "errno: %u[%s].\n", status, strerror(status) );
+    }
 
-	LOG ( "%'lu After semaphore broadcast of %p:\n", getIntervalTime(),
+    LOG ( "%'lu After semaphore broadcast of %p:\n", getIntervalTime(),
           semaphore );
-	SEM_DUMP ( semaphore );
+    SEM_DUMP ( semaphore );
 }
 
 
@@ -99,47 +99,47 @@ static void semaphoreCleanupHandler ( void* arg )
 
 void semaphoreWait ( semaphore_p semaphore )
 {
-	int status;
+    int status;
 
-	//
-	//	If the semaphore count is at 0 then the resource is not available so
-	//	we need to wait for it to become available.  This is done in a "while"
-	//	loop because we could be released spuriously due to a very small
-	//	windown in the semaphore code that results in more than one process
-	//	being released at times.  By checking the semaphore again after being
-	//	released, we guarantee that only one process will actually acquire the
-	//	semaphore.
-	//
-	LOG ( "%'lu Before semaphore wait on %p:\n", getIntervalTime(),
+    //
+    //  If the semaphore count is at 0 then the resource is not available so
+    //  we need to wait for it to become available.  This is done in a "while"
+    //  loop because we could be released spuriously due to a very small
+    //  windown in the semaphore code that results in more than one process
+    //  being released at times.  By checking the semaphore again after being
+    //  released, we guarantee that only one process will actually acquire the
+    //  semaphore.
+    //
+    LOG ( "%'lu Before semaphore wait on %p:\n", getIntervalTime(),
           semaphore );
-	SEM_DUMP ( semaphore );
+    SEM_DUMP ( semaphore );
 
-	while ( semaphore->messageCount == 0 )
-	{
-		LOG ( "%'lu In semaphore while[%p] - waiterCount: %d, messageCount: %d\n",
-				 getIntervalTime(), semaphore, semaphore->waiterCount,
-				 semaphore->messageCount );
+    while ( semaphore->messageCount == 0 )
+    {
+        LOG ( "%'lu In semaphore while[%p] - waiterCount: %d, messageCount: %d\n",
+               getIntervalTime(), semaphore, semaphore->waiterCount,
+               semaphore->messageCount );
 
         //
         //  Install the cancellation cleanup handler function.
         //
         pthread_cleanup_push ( semaphoreCleanupHandler, &semaphore->mutex );
 
-		status = pthread_cond_wait ( &semaphore->conditionVariable,
-									 &semaphore->mutex );
-		if ( status != 0 )
-		{
-			printf ( "Unable to wait on condition variable - "
-					 "errno: %u[%s].\n", status, strerror(status) );
-		}
+        status = pthread_cond_wait ( &semaphore->conditionVariable,
+                                     &semaphore->mutex );
+        if ( status != 0 )
+        {
+            printf ( "Unable to wait on condition variable - "
+                     "errno: %u[%s].\n", status, strerror(status) );
+        }
         //
         //  Release the cancellation cleanup handler function.
         //
         pthread_cleanup_pop ( 0 );
-	}
-	LOG ( "%'lu After semaphore wait on %p:\n", getIntervalTime(),
+    }
+    LOG ( "%'lu After semaphore wait on %p:\n", getIntervalTime(),
           semaphore );
-	SEM_DUMP ( semaphore );
+    SEM_DUMP ( semaphore );
 }
 
 /*! @} */

--- a/core/sharedMemoryLocks.h
+++ b/core/sharedMemoryLocks.h
@@ -8,10 +8,10 @@
 
 /*!----------------------------------------------------------------------------
 
-	@file sharedMemoryLocks.h
+    @file sharedMemoryLocks.h
 
-	This file contains the declarations of the semaphore objects and member
-	functions.
+    This file contains the declarations of the semaphore objects and member
+    functions.
 
 -----------------------------------------------------------------------------*/
 
@@ -24,26 +24,26 @@
 /*! @{ */
 
 //
-//	Define the semaphore control structure.
+//  Define the semaphore control structure.
 //
 typedef struct semaphore_t
 {
-	pthread_mutex_t mutex;
-	pthread_cond_t  conditionVariable;
-	int             messageCount;
-	int             waiterCount;
+    pthread_mutex_t mutex;
+    pthread_cond_t  conditionVariable;
+    int             messageCount;
+    int             waiterCount;
 
 }   semaphore_t, *semaphore_p;
 
 
 //
-//	Define the semaphore member functions.
+//  Define the semaphore member functions.
 //
 void semaphorePost ( semaphore_p semaphore );
 void semaphoreWait ( semaphore_p semaphore );
 
 
-#endif		// End of #ifndef SHARED_MEMORY_LOCKS_H
+#endif     // End of #ifndef SHARED_MEMORY_LOCKS_H
 
 /*! @} */
 

--- a/core/tests/btreeTests.c
+++ b/core/tests/btreeTests.c
@@ -9,9 +9,9 @@
 
 /*!----------------------------------------------------------------------------
 
-	@file      btreeTests.c
+    @file      btreeTests.c
 
-	This file contains some fairly extensive tests of the shared memory btree
+    This file contains some fairly extensive tests of the shared memory btree
     code.
 
 -----------------------------------------------------------------------------*/

--- a/core/tests/dump.c
+++ b/core/tests/dump.c
@@ -8,16 +8,16 @@
 
 /*!----------------------------------------------------------------------------
 
-	@file dump.c
+    @file dump.c
 
-	This file contains a utility function to dump the contents of the shared
-	memory buffers.  This is designed to be used during setup and debugging to
-	enable the user to see the state of the shared memory segement after some
-	changes have been made to it.
+    This file contains a utility function to dump the contents of the shared
+    memory buffers.  This is designed to be used during setup and debugging to
+    enable the user to see the state of the shared memory segement after some
+    changes have been made to it.
 
-	Note that this file is the main entry point for the dump executable and
-	that most of the actual work of dumping the data is done by functions in
-	the utilities library.
+    Note that this file is the main entry point for the dump executable and
+    that most of the actual work of dumping the data is done by functions in
+    the utilities library.
 
 -----------------------------------------------------------------------------*/
 
@@ -34,16 +34,16 @@ extern sharedMemory_t* smControl;
 /*! @{ */
 
 //
-//	WARNING!!!: All references (and pointers) to data in the can message
-//	buffer is performed by using the index into the array of messages.  All of
-//	these references need to be relocatable references so this will work in
-//	multiple processes that have their shared memory segments mapped to
-//	different base addresses.
+//  WARNING!!!: All references (and pointers) to data in the can message
+//  buffer is performed by using the index into the array of messages.  All of
+//  these references need to be relocatable references so this will work in
+//  multiple processes that have their shared memory segments mapped to
+//  different base addresses.
 //
 
 
 //
-//	Define the usage message function.
+//  Define the usage message function.
 //
 static void usage ( const char* executable )
 {
@@ -67,35 +67,35 @@ r   -d    Dump for domain  int         0      \n\
 
 /*!-----------------------------------------------------------------------
 
-	m a i n
+    m a i n
 
-	@brief The main entry point for this compilation unit.
+    @brief The main entry point for this compilation unit.
 
-	This function will perform the dump of the shared memory segment signal
-	lists according to the parameters that the user has specified.
+    This function will perform the dump of the shared memory segment signal
+    lists according to the parameters that the user has specified.
 
-	@return  0 - This function completed without errors
+    @return  0 - This function completed without errors
     @return !0 - The error code that was encountered
 
 ------------------------------------------------------------------------*/
 int main ( int argc, char* const argv[] )
 {
-	unsigned long messagesToDump = 4;
-	unsigned long listsToDump    = 4;
+    unsigned long messagesToDump = 4;
+    unsigned long listsToDump    = 4;
     unsigned int  domain         = 0;
     unsigned int  key            = 0;
 
-	//
-	//	The following locale settings will allow the use of the comma
-	//	"thousands" separator format specifier to be used.  e.g. "10000"
-	//	will print as "10,000" (using the %'u spec.).
-	//
-	setlocale ( LC_ALL, "");
+    //
+    //  The following locale settings will allow the use of the comma
+    //  "thousands" separator format specifier to be used.  e.g. "10000"
+    //  will print as "10,000" (using the %'u spec.).
+    //
+    setlocale ( LC_ALL, "");
 
     //
-    //	Parse any command line options the user may have supplied.
+    //  Parse any command line options the user may have supplied.
     //
-	char ch;
+    char ch;
 
     while ( ( ch = getopt ( argc, argv, "ad:hk:l:m:?" ) ) != -1 )
     {
@@ -108,45 +108,45 @@ int main ( int argc, char* const argv[] )
 
             break;
 
-		  //
-		  //	Get the requested domain to dump.
-		  //
-		  case 'd':
-		    domain = atol ( optarg );
-			break;
+          //
+          //  Get the requested domain to dump.
+          //
+          case 'd':
+            domain = atol ( optarg );
+            break;
 
-		  //
-		  //	Get the requested key to dump.
-		  //
-		  case 'k':
-		    key = atol ( optarg );
-			break;
+          //
+          //  Get the requested key to dump.
+          //
+          case 'k':
+            key = atol ( optarg );
+            break;
 
-		  //
-		  //	Get the requested list count.
-		  //
-		  case 'l':
-		    listsToDump = atol ( optarg );
-			if ( listsToDump <= 0 )
-			{
-				LOG ( "Invalid list count[%lu] specified.\n", listsToDump );
-				usage ( argv[0] );
-				exit (255);
-			}
-			break;
+          //
+          //  Get the requested list count.
+          //
+          case 'l':
+            listsToDump = atol ( optarg );
+            if ( listsToDump <= 0 )
+            {
+                LOG ( "Invalid list count[%lu] specified.\n", listsToDump );
+                usage ( argv[0] );
+                exit (255);
+            }
+            break;
 
-		  //
-		  //	Get the requested message count.
-		  //
-		  case 'm':
-		    messagesToDump = atol ( optarg );
-			if ( messagesToDump <= 0 )
-			{
-				LOG ( "Invalid message count[%lu] specified.\n", messagesToDump );
-				usage ( argv[0] );
-				exit (255);
-			}
-			break;
+          //
+          //  Get the requested message count.
+          //
+          case 'm':
+            messagesToDump = atol ( optarg );
+            if ( messagesToDump <= 0 )
+            {
+                LOG ( "Invalid message count[%lu] specified.\n", messagesToDump );
+                usage ( argv[0] );
+                exit (255);
+            }
+            break;
 
           //
           //    Display the help message.
@@ -159,29 +159,29 @@ int main ( int argc, char* const argv[] )
         }
     }
     //
-	//	If the user supplied any arguments other than the buffer size value,
-	//	they are not valid arguments so complain and quit.
+    //  If the user supplied any arguments other than the buffer size value,
+    //  they are not valid arguments so complain and quit.
     //
-	argc -= optind;
+    argc -= optind;
     if ( argc != 0 )
     {
         printf ( "Invalid parameters[s] encountered: %s\n", argv[argc] );
         usage ( argv[0] );
         exit (255);
     }
-	//
-	//	Open the shared memory file.
-	//
-	//	Note that if the shared memory segment does not already exist, this
-	//	call will create it.
-	//
-	vsi_core_open ( false );
+    //
+    //  Open the shared memory file.
+    //
+    //  Note that if the shared memory segment does not already exist, this
+    //  call will create it.
+    //
+    vsi_core_open ( false );
 
-	//
-	//	For each of the messages we were asked to dump...
-	//
-	LOG ( "Beginning dump of VSI core data store[%s]...\n",
-	         SHARED_MEMORY_SEGMENT_NAME );
+    //
+    //  For each of the messages we were asked to dump...
+    //
+    LOG ( "Beginning dump of VSI core data store[%s]...\n",
+             SHARED_MEMORY_SEGMENT_NAME );
     //
     //  If the user did not specify a key, dump starting at the beginning
     //  of the signal list.
@@ -189,7 +189,7 @@ int main ( int argc, char* const argv[] )
     if ( key == 0 )
     {
         //
-        //	Go dump all of the current signals.
+        //  Go dump all of the current signals.
         //
         dumpAllSignals ( messagesToDump );
     }
@@ -206,31 +206,31 @@ int main ( int argc, char* const argv[] )
         desiredSignal.key    = key;
 
         //
-		//  Get the signal list for this domain/key value.
-		//
-		signalListFound = btree_search ( &smControl->signals, &desiredSignal );
+        //  Get the signal list for this domain/key value.
+        //
+        signalListFound = btree_search ( &smControl->signals, &desiredSignal );
 
-		//
-		//  If the domain/key was not found, issue an error message.
-		//
-		if ( signalListFound == NULL )
+        //
+        //  If the domain/key was not found, issue an error message.
+        //
+        if ( signalListFound == NULL )
         {
             printf ( "Error: No signal list defined for %d/%d\n", domain, key );
             return 255;
         }
         //
-        //	If we found the requested signal list, go dump it.
+        //  If we found the requested signal list, go dump it.
         //
         dumpSignalList ( signalListFound, messagesToDump );
     }
-	//
-	//	Close our shared memory segment and exit.
-	//
-	vsi_core_close();
+    //
+    //  Close our shared memory segment and exit.
+    //
+    vsi_core_close();
 
-	//
-	//	Return a good completion code to the caller.
-	//
+    //
+    //  Return a good completion code to the caller.
+    //
     return 0;
 }
 

--- a/core/tests/fetch.c
+++ b/core/tests/fetch.c
@@ -8,10 +8,10 @@
 
 /*!----------------------------------------------------------------------------
 
-	@file fetch.c
+    @file fetch.c
 
-	This file will find and delete records from the shared memory message
-	pool.
+    This file will find and delete records from the shared memory message
+    pool.
 
 -----------------------------------------------------------------------------*/
 
@@ -30,16 +30,16 @@
 /*! @{ */
 
 //
-//	WARNING!!!: All references (and pointers) to data in the can message
-//	buffer is performed by using the index into the array of messages.  All of
-//	these references need to be relocatable references so this will work in
-//	multiple processes that have their shared memory segments mapped to
-//	different base addresses.
+//  WARNING!!!: All references (and pointers) to data in the can message
+//  buffer is performed by using the index into the array of messages.  All of
+//  these references need to be relocatable references so this will work in
+//  multiple processes that have their shared memory segments mapped to
+//  different base addresses.
 //
 
 
 //
-//	Define the usage message function.
+//  Define the usage message function.
 //
 static void usage ( const char* executable )
 {
@@ -62,71 +62,71 @@ Usage: %s options\n\
 
 /*!-----------------------------------------------------------------------
 
-	m a i n
+    m a i n
 
-	@brief  The main entry point for this compilation unit.
+    @brief  The main entry point for this compilation unit.
 
-	This function will locate and remove messages from the shared memory
-	segment as specified by the user.  By default, it will remove 1M messages
-	in sequential order.
+    This function will locate and remove messages from the shared memory
+    segment as specified by the user.  By default, it will remove 1M messages
+    in sequential order.
 
-	@return  0 - This function completed without errors
+    @return  0 - This function completed without errors
     @return !0 - The error code that was encountered
 
 ------------------------------------------------------------------------*/
 int main ( int argc, char* const argv[] )
 {
-	unsigned long messagesToStore = 1000000;
-	bool          continuousRun = false;
-	bool          useRandom = false;
-
-	//
-	//	The following locale settings will allow the use of the comma
-	//	"thousands" separator format specifier to be used.  e.g. "10000"
-	//	will print as "10,000" (using the %'u spec.).
-	//
-	setlocale ( LC_ALL, "");
+    unsigned long messagesToStore = 1000000;
+    bool          continuousRun = false;
+    bool          useRandom = false;
 
     //
-    //	Parse any command line options the user may have supplied.
+    //  The following locale settings will allow the use of the comma
+    //  "thousands" separator format specifier to be used.  e.g. "10000"
+    //  will print as "10,000" (using the %'u spec.).
     //
-	int status;
-	char ch;
+    setlocale ( LC_ALL, "");
+
+    //
+    //  Parse any command line options the user may have supplied.
+    //
+    int status;
+    char ch;
 
     while ( ( ch = getopt ( argc, argv, "chm:r?" ) ) != -1 )
     {
         switch ( ch )
         {
-		  //
-		  //	Get the continuous run option flag if present.
-		  //
-		  case 'c':
-			LOG ( "Record writing will run continuously. <ctrl-c> to "
-			      "quit...\n" );
-		    continuousRun = true;
-			break;
+          //
+          //  Get the continuous run option flag if present.
+          //
+          case 'c':
+            LOG ( "Record writing will run continuously. <ctrl-c> to "
+                  "quit...\n" );
+            continuousRun = true;
+            break;
 
-		  //
-		  //	Get the requested buffer size argument and validate it.
-		  //
-		  case 'm':
-		    messagesToStore = atol ( optarg );
-			if ( messagesToStore <= 0 )
-			{
-				printf ( "Invalid buffer count[%lu] specified.\n",
-						 messagesToStore );
-				usage ( argv[0] );
-				exit (255);
-			}
-			break;
+          //
+          //  Get the requested buffer size argument and validate it.
+          //
+          case 'm':
+            messagesToStore = atol ( optarg );
+            if ( messagesToStore <= 0 )
+            {
+                printf ( "Invalid buffer count[%lu] specified.\n",
+                         messagesToStore );
+                usage ( argv[0] );
+                exit (255);
+            }
+            break;
 
-		  //
-		  //	Get the random insert option flag if present.
-		  //
-		  case 'r':
-			LOG ( "Record writing will be random.\n" );
-		    useRandom = true;
-			break;
+          //
+          //  Get the random insert option flag if present.
+          //
+          case 'r':
+            LOG ( "Record writing will be random.\n" );
+            useRandom = true;
+            break;
 
           case 'h':
           case '?':
@@ -136,131 +136,131 @@ int main ( int argc, char* const argv[] )
         }
     }
     //
-	//	If the user supplied any arguments not parsed above, they are not
-	//  valid arguments so complain and quit.
+    //  If the user supplied any arguments not parsed above, they are not
+    //  valid arguments so complain and quit.
     //
-	argc -= optind;
+    argc -= optind;
     if ( argc != 0 )
     {
         printf ( "Invalid parameters[s] encountered: %s\n", argv[argc] );
         usage ( argv[0] );
         exit (255);
     }
-	//
-	//	Open the shared memory file.
-	//
-	//	Note that if the shared memory segment does not already exist, this
-	//	call will create it.
-	//
-	vsi_core_open ( false );
+    //
+    //  Open the shared memory file.
+    //
+    //  Note that if the shared memory segment does not already exist, this
+    //  call will create it.
+    //
+    vsi_core_open ( false );
 
-	//
-	//	Define the message that we will use to retrieve records from the
-	//	shared memory segment.
-	//
-	char message[32];
-	unsigned long messageKey;
+    //
+    //  Define the message that we will use to retrieve records from the
+    //  shared memory segment.
+    //
+    char message[32];
+    unsigned long messageKey;
 
-	(void) memset ( &message, 0, sizeof(message) );
+    (void) memset ( &message, 0, sizeof(message) );
 
-	//
-	//	Define the performance spec variables.
-	//
-	struct timespec startTime;
-	struct timespec stopTime;
+    //
+    //  Define the performance spec variables.
+    //
+    struct timespec startTime;
+    struct timespec stopTime;
     unsigned long   startTimeNs;
     unsigned long   stopTimeNs;
     unsigned long   diffTimeNs;
     unsigned long   totalNs = 0;
     unsigned long   totalRecords = 0;
-	unsigned long   rps;
+    unsigned long   rps;
 
 #define NS_PER_SEC ( 1000000000 )
 
     //
-    //	Initialize the random number generator.
+    //  Initialize the random number generator.
     //
     srand ( 1 );
 
-	//
-	//	Repeat the following at least once...
-	//
-	//	Note that if "continuous" mode has been selected, this loop will run
-	//	forever.  The user will need to kill it manually from the command line.
-	//
-	//	Also note that the inclusion of the "rand" function call in the loop
-	//	below has significantly slowed down the performance of the loop.
-	//
-	do
-	{
-		//
-		//	For the number of iterations specified by the caller...
-		//
-		clock_gettime(CLOCK_REALTIME, &startTime);
-		for ( unsigned int i = 0; i < messagesToStore; i++ )
-		{
-			//
-			//	Generate a message key and use that to populate our message
-			//	structure.  Note that this index may be random or sequential
-			//	depending on whether the user specified the random behavior.
-			//	The default is to use the sequential mode.
-			//
-			if ( useRandom )
-			{
-				messageKey = rand();
-			}
-			else
-			{
-				messageKey = i;
-			}
-			//
-			//	Go retrieve this message from the message pool.
-			//
-			//	Note that for these tests, all of the messsages in the message
+    //
+    //  Repeat the following at least once...
+    //
+    //  Note that if "continuous" mode has been selected, this loop will run
+    //  forever.  The user will need to kill it manually from the command line.
+    //
+    //  Also note that the inclusion of the "rand" function call in the loop
+    //  below has significantly slowed down the performance of the loop.
+    //
+    do
+    {
+        //
+        //  For the number of iterations specified by the caller...
+        //
+        clock_gettime(CLOCK_REALTIME, &startTime);
+        for ( unsigned int i = 0; i < messagesToStore; i++ )
+        {
+            //
+            //  Generate a message key and use that to populate our message
+            //  structure.  Note that this index may be random or sequential
+            //  depending on whether the user specified the random behavior.
+            //  The default is to use the sequential mode.
+            //
+            if ( useRandom )
+            {
+                messageKey = rand();
+            }
+            else
+            {
+                messageKey = i;
+            }
+            //
+            //  Go retrieve this message from the message pool.
+            //
+            //  Note that for these tests, all of the messsages in the message
             //  pool will be retrieved from the "CAN" domain.
-			//
+            //
             unsigned long messageSize = sizeof(message);
             status = vsi_core_fetch_wait ( DOMAIN_CAN, messageKey,
                                            &messageSize, &message );
-			if ( status != 0 )
-			{
-				printf ( "====> ERROR: Fetching message[%lu] - Error %d\n",
-						 messageKey, status );
-			}
-		}
-		clock_gettime(CLOCK_REALTIME, &stopTime);
+            if ( status != 0 )
+            {
+                printf ( "====> ERROR: Fetching message[%lu] - Error %d\n",
+                         messageKey, status );
+            }
+        }
+        clock_gettime(CLOCK_REALTIME, &stopTime);
 
-		//
-		//	Compute all of the timing metrics.
-		//
-		startTimeNs = startTime.tv_sec * NS_PER_SEC + startTime.tv_nsec;
-		stopTimeNs  = stopTime.tv_sec  * NS_PER_SEC + stopTime.tv_nsec;
-		diffTimeNs = stopTimeNs - startTimeNs;
-		rps = messagesToStore / ( diffTimeNs / (double)NS_PER_SEC );
-		totalNs += diffTimeNs;
-		totalRecords += messagesToStore;
+        //
+        //  Compute all of the timing metrics.
+        //
+        startTimeNs = startTime.tv_sec * NS_PER_SEC + startTime.tv_nsec;
+        stopTimeNs  = stopTime.tv_sec  * NS_PER_SEC + stopTime.tv_nsec;
+        diffTimeNs = stopTimeNs - startTimeNs;
+        rps = messagesToStore / ( diffTimeNs / (double)NS_PER_SEC );
+        totalNs += diffTimeNs;
+        totalRecords += messagesToStore;
 
-		//
-		//	Display the amount of time it took to process this iteration of the
-		//	insert loop.
-		//
-		printf ( "%'lu records in %'lu nsec. %'lu msec. - %'lu records/sec - Avg: %'lu\n",
-				 messagesToStore,
-				 stopTimeNs - startTimeNs,
-				 (stopTimeNs - startTimeNs) / 1000000,
-				 rps,
-				 (unsigned long)( totalRecords / ( totalNs / (double)NS_PER_SEC ) )
-			   );
+        //
+        //  Display the amount of time it took to process this iteration of the
+        //  insert loop.
+        //
+        printf ( "%'lu records in %'lu nsec. %'lu msec. - %'lu records/sec - Avg: %'lu\n",
+                 messagesToStore,
+                 stopTimeNs - startTimeNs,
+                 (stopTimeNs - startTimeNs) / 1000000,
+                 rps,
+                 (unsigned long)( totalRecords / ( totalNs / (double)NS_PER_SEC ) )
+               );
 
-	}   while ( continuousRun );
-	//
-	//	Close our shared memory segment and exit.
-	//
-	vsi_core_close();
+    }   while ( continuousRun );
+    //
+    //  Close our shared memory segment and exit.
+    //
+    vsi_core_close();
 
-	//
-	//	Return a good completion code to the caller.
-	//
+    //
+    //  Return a good completion code to the caller.
+    //
     return 0;
 }
 

--- a/core/tests/flush.c
+++ b/core/tests/flush.c
@@ -8,9 +8,9 @@
 
 /*!----------------------------------------------------------------------------
 
-	@file readRecord.c
+    @file readRecord.c
 
-	This file will read a single record from the shared memory message buffers.
+    This file will read a single record from the shared memory message buffers.
 
 -----------------------------------------------------------------------------*/
 
@@ -29,7 +29,7 @@
 /*! @{ */
 
 //
-//	Define the usage message function.
+//  Define the usage message function.
 //
 static void usage ( const char* executable )
 {
@@ -38,8 +38,8 @@ Usage: %s options\n\
 \n\
   Option     Meaning       Type     Default   \n\
   ======  ==============  ======  =========== \n\
-	-d    Domain Value     int        CAN     \n\
-	-k    Key Value        int         0	  \n\
+    -d    Domain Value     int        CAN     \n\
+    -k    Key Value        int         0      \n\
     -h    Help Message     N/A        N/A     \n\
     -?    Help Message     N/A        N/A     \n\
 \n\n\
@@ -50,61 +50,61 @@ Usage: %s options\n\
 
 /*!-----------------------------------------------------------------------
 
-	m a i n
+    m a i n
 
-	@brief The main entry point for this compilation unit.
+    @brief The main entry point for this compilation unit.
 
-	This function will read and remove a single message from the shared memory segment
-	as specified by the user.
+    This function will read and remove a single message from the shared memory segment
+    as specified by the user.
 
-	The "domain" will default to "CAN" if not specified by the caller and the
-	"key" value will default to 0.
+    The "domain" will default to "CAN" if not specified by the caller and the
+    "key" value will default to 0.
 
-	Note that the "body" data will be read as 8 bytes of data and interpreted
-	as a numeric value and as an ASCII string on output.
+    Note that the "body" data will be read as 8 bytes of data and interpreted
+    as a numeric value and as an ASCII string on output.
 
-	@return  0 - This function completed without errors
-	@return !0 - The error code that was encountered
+    @return  0 - This function completed without errors
+    @return !0 - The error code that was encountered
 
 ------------------------------------------------------------------------*/
 int main ( int argc, char* const argv[] )
 {
-	//
-	//	The following locale settings will allow the use of the comma
-	//	"thousands" separator format specifier to be used.  e.g. "10000"
-	//	will print as "10,000" (using the %'u spec.).
-	//
-	setlocale ( LC_ALL, "");
+    //
+    //  The following locale settings will allow the use of the comma
+    //  "thousands" separator format specifier to be used.  e.g. "10000"
+    //  will print as "10,000" (using the %'u spec.).
+    //
+    setlocale ( LC_ALL, "");
 
     //
-    //	Parse any command line options the user may have supplied.
+    //  Parse any command line options the user may have supplied.
     //
-	unsigned long keyValue = 0;
-	domain_t domainValue   = DOMAIN_CAN;
-	int status             = 0;
-	char ch                = 0;
+    unsigned long keyValue = 0;
+    domain_t domainValue   = DOMAIN_CAN;
+    int status             = 0;
+    char ch                = 0;
 
     while ( ( ch = getopt ( argc, argv, "d:k:nh?" ) ) != -1 )
     {
         switch ( ch )
         {
-		  //
-		  //	Get the requested domain value.
-		  //
-		  case 'd':
-		    domainValue = atol ( optarg );
-			LOG ( "Using domain value[%'lu]\n", domainValue );
-			break;
-		  //
-		  //	Get the requested key value.
-		  //
-		  case 'k':
-		    keyValue = atol ( optarg );
-			LOG ( "Using key value[%'lu]\n", keyValue );
-			break;
-		  //
-		  //	Display the help message.
-		  //
+          //
+          //  Get the requested domain value.
+          //
+          case 'd':
+            domainValue = atol ( optarg );
+            LOG ( "Using domain value[%'lu]\n", domainValue );
+            break;
+          //
+          //  Get the requested key value.
+          //
+          case 'k':
+            keyValue = atol ( optarg );
+            LOG ( "Using key value[%'lu]\n", keyValue );
+            break;
+          //
+          //  Display the help message.
+          //
           case 'h':
           case '?':
           default:
@@ -113,42 +113,42 @@ int main ( int argc, char* const argv[] )
         }
     }
     //
-	//	If the user supplied any arguments not parsed above, they are not
-	//	valid arguments so complain and quit.
+    //  If the user supplied any arguments not parsed above, they are not
+    //  valid arguments so complain and quit.
     //
-	argc -= optind;
+    argc -= optind;
     if ( argc != 0 )
     {
         printf ( "Invalid parameters[s] encountered: %s\n", argv[argc] );
         usage ( argv[0] );
         exit (255);
     }
-	//
-	//	Open the shared memory file.
-	//
-	//	Note that if the shared memory segment does not already exist, this
-	//	call will create it.
-	//
-	vsi_core_open ( false );
+    //
+    //  Open the shared memory file.
+    //
+    //  Note that if the shared memory segment does not already exist, this
+    //  call will create it.
+    //
+    vsi_core_open ( false );
 
-	//
-	//	Go flush all messages with the given domain and key.
-	//
-	LOG ( "  Flushing domain: %'lu\n  key...: %'lu\n", domainValue, keyValue );
+    //
+    //  Go flush all messages with the given domain and key.
+    //
+    LOG ( "  Flushing domain: %'lu\n  key...: %'lu\n", domainValue, keyValue );
 
     status = vsi_core_flush_signal ( domainValue, keyValue );
-	if ( status != 0 )
-	{
-		printf ( "----> Error %d[%s] returned\n", status, strerror(status) );
-	}
-	//
-	//	Close our shared memory segment and exit.
-	//
-	vsi_core_close();
+    if ( status != 0 )
+    {
+        printf ( "----> Error %d[%s] returned\n", status, strerror(status) );
+    }
+    //
+    //  Close our shared memory segment and exit.
+    //
+    vsi_core_close();
 
-	//
-	//	Return a good completion code to the caller.
-	//
+    //
+    //  Return a good completion code to the caller.
+    //
     return 0;
 }
 

--- a/core/tests/insert.c
+++ b/core/tests/insert.c
@@ -8,9 +8,9 @@
 
 /*!----------------------------------------------------------------------------
 
-	@file insert.c
+    @file insert.c
 
-	This file will write records into the shared memory message buffers.
+    This file will write records into the shared memory message buffers.
 
 -----------------------------------------------------------------------------*/
 
@@ -28,16 +28,16 @@
 /*! @{ */
 
 //
-//	WARNING!!!: All references (and pointers) to data in the can message
-//	buffer are performed by using the index into the array of messages.  All
-//	of these references need to be relocatable references so this will work in
-//	multiple processes that have their shared memory segments mapped to
-//	different base addresses.
+//  WARNING!!!: All references (and pointers) to data in the can message
+//  buffer are performed by using the index into the array of messages.  All
+//  of these references need to be relocatable references so this will work in
+//  multiple processes that have their shared memory segments mapped to
+//  different base addresses.
 //
 
 
 //
-//	Define the usage message function.
+//  Define the usage message function.
 //
 static void usage ( const char* executable )
 {
@@ -59,73 +59,73 @@ Usage: %s options\n\
 
 /*!-----------------------------------------------------------------------
 
-	m a i n
+    m a i n
 
-	@brief The main entry point for this compilation unit.
+    @brief The main entry point for this compilation unit.
 
-	This function will insert messages into the shared memory segment as
-	specified by the user.  By default, it will insert 1M messages in
-	sequential order.
+    This function will insert messages into the shared memory segment as
+    specified by the user.  By default, it will insert 1M messages in
+    sequential order.
 
-	@return  0 - This function completed without errors
-	@return !0 - The error code that was encountered
+    @return  0 - This function completed without errors
+    @return !0 - The error code that was encountered
 
 ------------------------------------------------------------------------*/
 int main ( int argc, char* const argv[] )
 {
-	unsigned long messagesToStore = 1000000;
-	bool          continuousRun = false;
-	bool          useRandom = false;
-
-	//
-	//	The following locale settings will allow the use of the comma
-	//	"thousands" separator format specifier to be used.  e.g. "10000"
-	//	will print as "10,000" (using the %'u spec.).
-	//
-	setlocale ( LC_ALL, "");
+    unsigned long messagesToStore = 1000000;
+    bool          continuousRun = false;
+    bool          useRandom = false;
 
     //
-    //	Parse any command line options the user may have supplied.
+    //  The following locale settings will allow the use of the comma
+    //  "thousands" separator format specifier to be used.  e.g. "10000"
+    //  will print as "10,000" (using the %'u spec.).
     //
-	char ch;
+    setlocale ( LC_ALL, "");
+
+    //
+    //  Parse any command line options the user may have supplied.
+    //
+    char ch;
 
     while ( ( ch = getopt ( argc, argv, "cm:rh?" ) ) != -1 )
     {
         switch ( ch )
         {
-		  //
-		  //	Get the continuous run option flag if present.
-		  //
-		  case 'c':
-			LOG ( "Record writing will run continuously. <ctrl-c> to "
-			      "quit...\n" );
-		    continuousRun = true;
-			break;
+          //
+          //  Get the continuous run option flag if present.
+          //
+          case 'c':
+            LOG ( "Record writing will run continuously. <ctrl-c> to "
+                  "quit...\n" );
+            continuousRun = true;
+            break;
 
-		  //
-		  //	Get the requested buffer size argument and validate it.
-		  //
-		  case 'm':
-		    messagesToStore = atol ( optarg );
-			if ( messagesToStore <= 0 )
-			{
-				LOG ( "Invalid message count[%lu] specified.\n",
-						 messagesToStore );
-				usage ( argv[0] );
-				exit (255);
-			}
-			break;
-		  //
-		  //	Get the random insert option flag if present.
-		  //
-		  case 'r':
-			LOG ( "Record writing will be random.\n" );
-		    useRandom = true;
-			break;
+          //
+          //  Get the requested buffer size argument and validate it.
+          //
+          case 'm':
+            messagesToStore = atol ( optarg );
+            if ( messagesToStore <= 0 )
+            {
+                LOG ( "Invalid message count[%lu] specified.\n",
+                      messagesToStore );
+                usage ( argv[0] );
+                exit (255);
+            }
+            break;
+          //
+          //  Get the random insert option flag if present.
+          //
+          case 'r':
+            LOG ( "Record writing will be random.\n" );
+            useRandom = true;
+            break;
 
-		  //
-		  //	Display the help message.
-		  //
+          //
+          //  Display the help message.
+          //
           case 'h':
           case '?':
           default:
@@ -134,124 +134,124 @@ int main ( int argc, char* const argv[] )
         }
     }
     //
-	//	If the user supplied any arguments not parsed above, they are not
-	//	valid arguments so complain and quit.
+    //  If the user supplied any arguments not parsed above, they are not
+    //  valid arguments so complain and quit.
     //
-	argc -= optind;
+    argc -= optind;
     if ( argc != 0 )
     {
         printf ( "Invalid parameters[s] encountered: %s\n", argv[argc] );
         usage ( argv[0] );
         exit (255);
     }
-	//
-	//	Open the shared memory file.
-	//
-	//	Note that if the shared memory segment does not already exist, this
-	//	call will create it.
-	//
-	vsi_core_open ( false );
+    //
+    //  Open the shared memory file.
+    //
+    //  Note that if the shared memory segment does not already exist, this
+    //  call will create it.
+    //
+    vsi_core_open ( false );
 
-	//
-	//	Define the message that we will use to insert records into the shared
-	//	memory segment.
-	//
-	char          message[8];
-	unsigned long messageKey;
+    //
+    //  Define the message that we will use to insert records into the shared
+    //  memory segment.
+    //
+    char          message[8];
+    unsigned long messageKey;
 
-	(void) memset ( &message, 0, sizeof(message) );
+    (void) memset ( &message, 0, sizeof(message) );
 
-	//
-	//	Define the performance spec variables.
-	//
-	struct timespec startTime;
-	struct timespec stopTime;
+    //
+    //  Define the performance spec variables.
+    //
+    struct timespec startTime;
+    struct timespec stopTime;
     unsigned long   startTimeNs;
     unsigned long   stopTimeNs;
     unsigned long   diffTimeNs;
     unsigned long   totalNs = 0;
     unsigned long   totalRecords = 0;
-	unsigned long   rps;
+    unsigned long   rps;
 
 #define NS_PER_SEC ( 1000000000 )
 
     //
-    //	Initialize the random number generator.
+    //  Initialize the random number generator.
     //
     srand ( 1 );
 
-	//
-	//	Repeat the following at least once...
-	//
-	//	Note that if "continuous" mode has been selected, this loop will run
-	//	forever.  The user will need to kill it manually from the command line.
-	//
-	//	Also note that the inclusion of the "rand" function call in the loop
-	//	below has significantly slowed down the performance of the loop.
-	//
-	do
-	{
-		//
-		//	For the number of iterations specified by the caller...
-		//
-		clock_gettime(CLOCK_REALTIME, &startTime);
-		for ( unsigned int i = 0; i < messagesToStore; i++ )
-		{
-			//
-			//	Generate a message key and use that to populate our message
-			//	structure.  Note that this index may be random or sequential
-			//	depending on whether the user specified the random behavior.
-			//	The default is to use the sequential mode.
-			//
-			if ( useRandom )
-			{
-				messageKey = rand();
-			}
-			else
-			{
-				messageKey = i % 1024;
-			}
-			//
-			//	Go insert this message into the message pool.
-			//
-			//	Note that for these tests, all of the messsages in the message
-			//	pool will be inserted in the "CAN" domain.
-			//
-			vsi_core_insert ( DOMAIN_CAN, messageKey, sizeof(message), &i );
-		}
-		clock_gettime(CLOCK_REALTIME, &stopTime);
+    //
+    //  Repeat the following at least once...
+    //
+    //  Note that if "continuous" mode has been selected, this loop will run
+    //  forever.  The user will need to kill it manually from the command line.
+    //
+    //  Also note that the inclusion of the "rand" function call in the loop
+    //  below has significantly slowed down the performance of the loop.
+    //
+    do
+    {
+        //
+        //  For the number of iterations specified by the caller...
+        //
+        clock_gettime(CLOCK_REALTIME, &startTime);
+        for ( unsigned int i = 0; i < messagesToStore; i++ )
+        {
+            //
+            //  Generate a message key and use that to populate our message
+            //  structure.  Note that this index may be random or sequential
+            //  depending on whether the user specified the random behavior.
+            //  The default is to use the sequential mode.
+            //
+            if ( useRandom )
+            {
+                messageKey = rand();
+            }
+            else
+            {
+                messageKey = i % 1024;
+            }
+            //
+            //  Go insert this message into the message pool.
+            //
+            //  Note that for these tests, all of the messsages in the message
+            //  pool will be inserted in the "CAN" domain.
+            //
+            vsi_core_insert ( DOMAIN_CAN, messageKey, sizeof(message), &i );
+        }
+        clock_gettime(CLOCK_REALTIME, &stopTime);
 
-		//
-		//	Compute all of the timing metrics.
-		//
-		startTimeNs = startTime.tv_sec * NS_PER_SEC + startTime.tv_nsec;
-		stopTimeNs  = stopTime.tv_sec  * NS_PER_SEC + stopTime.tv_nsec;
-		diffTimeNs = stopTimeNs - startTimeNs;
-		rps = messagesToStore / ( diffTimeNs / (double)NS_PER_SEC );
-		totalNs += diffTimeNs;
-		totalRecords += messagesToStore;
+        //
+        //  Compute all of the timing metrics.
+        //
+        startTimeNs = startTime.tv_sec * NS_PER_SEC + startTime.tv_nsec;
+        stopTimeNs  = stopTime.tv_sec  * NS_PER_SEC + stopTime.tv_nsec;
+        diffTimeNs = stopTimeNs - startTimeNs;
+        rps = messagesToStore / ( diffTimeNs / (double)NS_PER_SEC );
+        totalNs += diffTimeNs;
+        totalRecords += messagesToStore;
 
-		//
-		//	Display the amount of time it took to process this iteration of the
-		//	insert loop.
-		//
-		printf ( "%'lu records in %'lu nsec. %'lu msec. - %'lu records/sec - Avg: %'lu\n",
-				 messagesToStore,
-				 stopTimeNs - startTimeNs,
-				 (stopTimeNs - startTimeNs) / 1000000,
-				 rps,
-				 (unsigned long)( totalRecords / ( totalNs / (double)NS_PER_SEC ) )
-			   );
+        //
+        //  Display the amount of time it took to process this iteration of the
+        //  insert loop.
+        //
+        printf ( "%'lu records in %'lu nsec. %'lu msec. - %'lu records/sec - Avg: %'lu\n",
+                 messagesToStore,
+                 stopTimeNs - startTimeNs,
+                 (stopTimeNs - startTimeNs) / 1000000,
+                 rps,
+                 (unsigned long)( totalRecords / ( totalNs / (double)NS_PER_SEC ) )
+               );
 
-	}   while ( continuousRun );
-	//
-	//	Close our shared memory segment and exit.
-	//
-	vsi_core_close();
+    }   while ( continuousRun );
+    //
+    //  Close our shared memory segment and exit.
+    //
+    vsi_core_close();
 
-	//
-	//	Return a good completion code to the caller.
-	//
+    //
+    //  Return a good completion code to the caller.
+    //
     return 0;
 }
 

--- a/core/tests/readRecord.c
+++ b/core/tests/readRecord.c
@@ -8,9 +8,9 @@
 
 /*!----------------------------------------------------------------------------
 
-	@file readRecord.c
+    @file readRecord.c
 
-	This file will read a single record from the shared memory message buffers.
+    This file will read a single record from the shared memory message buffers.
 
 -----------------------------------------------------------------------------*/
 
@@ -29,7 +29,7 @@
 /*! @{ */
 
 //
-//	Define the usage message function.
+//  Define the usage message function.
 //
 static void usage ( const char* executable )
 {
@@ -38,9 +38,9 @@ Usage: %s options\n\
 \n\
   Option     Meaning       Type     Default   \n\
   ======  ==============  ======  =========== \n\
-	-d    Domain Value     int        CAN     \n\
-	-k    Key Value        int         0	  \n\
-	-n    Find Newest      N/A       false    \n\
+    -d    Domain Value     int        CAN     \n\
+    -k    Key Value        int         0      \n\
+    -n    Find Newest      N/A       false    \n\
     -h    Help Message     N/A        N/A     \n\
     -?    Help Message     N/A        N/A     \n\
 \n\n\
@@ -51,71 +51,71 @@ Usage: %s options\n\
 
 /*!-----------------------------------------------------------------------
 
-	m a i n
+    m a i n
 
-	@brief The main entry point for this compilation unit.
+    @brief The main entry point for this compilation unit.
 
-	This function will read and remove a single message from the shared memory segment
-	as specified by the user.
+    This function will read and remove a single message from the shared memory segment
+    as specified by the user.
 
-	The "domain" will default to "CAN" if not specified by the caller and the
-	"key" value will default to 0.
+    The "domain" will default to "CAN" if not specified by the caller and the
+    "key" value will default to 0.
 
-	Note that the "body" data will be read as 8 bytes of data and interpreted
-	as a numeric value and as an ASCII string on output.
+    Note that the "body" data will be read as 8 bytes of data and interpreted
+    as a numeric value and as an ASCII string on output.
 
-	@return  0 - This function completed without errors
-	@return !0 - The error code that was encountered
+    @return  0 - This function completed without errors
+    @return !0 - The error code that was encountered
 
 ------------------------------------------------------------------------*/
 int main ( int argc, char* const argv[] )
 {
-	//
-	//	The following locale settings will allow the use of the comma
-	//	"thousands" separator format specifier to be used.  e.g. "10000"
-	//	will print as "10,000" (using the %'u spec.).
-	//
-	setlocale ( LC_ALL, "");
+    //
+    //  The following locale settings will allow the use of the comma
+    //  "thousands" separator format specifier to be used.  e.g. "10000"
+    //  will print as "10,000" (using the %'u spec.).
+    //
+    setlocale ( LC_ALL, "");
 
     //
-    //	Parse any command line options the user may have supplied.
+    //  Parse any command line options the user may have supplied.
     //
-	char asciiData[9] = { 0 };		// We only copy 8 bytes so it is always
-									// null terminated
-	unsigned long keyValue = 0;
-	domain_t domainValue = DOMAIN_CAN;
-	int status = 0;
-	char ch;
+    char asciiData[9] = { 0 };  // We only copy 8 bytes so it is always
+                                // null terminated
+    unsigned long keyValue = 0;
+    domain_t domainValue = DOMAIN_CAN;
+    int status = 0;
+    char ch;
     bool getNewest = false;
 
     while ( ( ch = getopt ( argc, argv, "d:k:nh?" ) ) != -1 )
     {
         switch ( ch )
         {
-		  //
-		  //	Get the requested domain value.
-		  //
-		  case 'd':
-		    domainValue = atol ( optarg );
-			LOG ( "Using domain value[%'lu]\n", domainValue );
-			break;
-		  //
-		  //	Get the requested key value.
-		  //
-		  case 'k':
-		    keyValue = atol ( optarg );
-			LOG ( "Using key value[%'lu]\n", keyValue );
-			break;
-		  //
-		  //	Get the "newest" message flag.
-		  //
-		  case 'n':
-			LOG ( "Fetching the newest signal\n" );
+          //
+          //  Get the requested domain value.
+          //
+          case 'd':
+            domainValue = atol ( optarg );
+            LOG ( "Using domain value[%'lu]\n", domainValue );
+            break;
+          //
+          //  Get the requested key value.
+          //
+          case 'k':
+            keyValue = atol ( optarg );
+            LOG ( "Using key value[%'lu]\n", keyValue );
+            break;
+          //
+          //  Get the "newest" message flag.
+          //
+          case 'n':
+            LOG ( "Fetching the newest signal\n" );
             getNewest = true;
-			break;
-		  //
-		  //	Display the help message.
-		  //
+            break;
+          //
+          //  Display the help message.
+          //
           case 'h':
           case '?':
           default:
@@ -124,28 +124,28 @@ int main ( int argc, char* const argv[] )
         }
     }
     //
-	//	If the user supplied any arguments not parsed above, they are not
-	//	valid arguments so complain and quit.
+    //  If the user supplied any arguments not parsed above, they are not
+    //  valid arguments so complain and quit.
     //
-	argc -= optind;
+    argc -= optind;
     if ( argc != 0 )
     {
         printf ( "Invalid parameters[s] encountered: %s\n", argv[argc] );
         usage ( argv[0] );
         exit (255);
     }
-	//
-	//	Open the shared memory file.
-	//
-	//	Note that if the shared memory segment does not already exist, this
-	//	call will create it.
-	//
-	vsi_core_open ( false );
+    //
+    //  Open the shared memory file.
+    //
+    //  Note that if the shared memory segment does not already exist, this
+    //  call will create it.
+    //
+    vsi_core_open ( false );
 
-	//
-	//	Go read this message from the message pool.
-	//
-	LOG ( "  domain: %'lu\n  key...: %'lu\n", domainValue, keyValue );
+    //
+    //  Go read this message from the message pool.
+    //
+    LOG ( "  domain: %'lu\n  key...: %'lu\n", domainValue, keyValue );
 
     unsigned long dataSize = sizeof(asciiData) - 1;
     if ( getNewest )
@@ -158,24 +158,24 @@ int main ( int argc, char* const argv[] )
         status = vsi_core_fetch_wait ( domainValue, keyValue, &dataSize,
                                        asciiData );
     }
-	if ( status == 0 )
-	{
+    if ( status == 0 )
+    {
 #ifdef VSI_DEBUG
         HX_DUMP ( asciiData, dataSize, "  Value: " );
 #endif
-	}
-	else
-	{
-		printf ( "----> Error %d[%s] returned\n", status, strerror(status) );
-	}
-	//
-	//	Close our shared memory segment and exit.
-	//
-	vsi_core_close();
+    }
+    else
+    {
+        printf ( "----> Error %d[%s] returned\n", status, strerror(status) );
+    }
+    //
+    //  Close our shared memory segment and exit.
+    //
+    vsi_core_close();
 
-	//
-	//	Return a good completion code to the caller.
-	//
+    //
+    //  Return a good completion code to the caller.
+    //
     return 0;
 }
 

--- a/core/tests/smTests.c
+++ b/core/tests/smTests.c
@@ -9,9 +9,9 @@
 
 /*!----------------------------------------------------------------------------
 
-	@file smmTests.c
+    @file smmTests.c
 
-	This file contains the code to perform some stand-alone tests of the
+    This file contains the code to perform some stand-alone tests of the
     shared memory manager module.
 
 -----------------------------------------------------------------------------*/
@@ -30,7 +30,7 @@
 
 
 //
-//	Define the usage message function.
+//  Define the usage message function.
 //
 static void usage ( const char* executable )
 {
@@ -54,35 +54,35 @@ Usage: %s options\n\
 
 /*!-----------------------------------------------------------------------
 
-	m a i n
+    m a i n
 
-	@brief The main entry point for this compilation unit.
+    @brief The main entry point for this compilation unit.
 
-	This function will perform the dump of the shared memory segment data
-	structures according to the parameters that the user has specified.
+    This function will perform the dump of the shared memory segment data
+    structures according to the parameters that the user has specified.
 
-	@return  0 - This function completed without errors
+    @return  0 - This function completed without errors
     @return !0 - The error code that was encountered
 
 ------------------------------------------------------------------------*/
 int main ( int argc, char* const argv[] )
 {
-	unsigned long messagesToDump = 4;
-	unsigned long listsToDump    = 4;
-	// unsigned long domain         = 0;
-	// unsigned long key            = 0;
-
-	//
-	//	The following locale settings will allow the use of the comma
-	//	"thousands" separator format specifier to be used.  e.g. "10000"
-	//	will print as "10,000" (using the %'u spec.).
-	//
-	setlocale ( LC_ALL, "");
+    unsigned long messagesToDump = 4;
+    unsigned long listsToDump    = 4;
+    // unsigned long domain         = 0;
+    // unsigned long key            = 0;
 
     //
-    //	Parse any command line options the user may have supplied.
+    //  The following locale settings will allow the use of the comma
+    //  "thousands" separator format specifier to be used.  e.g. "10000"
+    //  will print as "10,000" (using the %'u spec.).
     //
-	char ch;
+    setlocale ( LC_ALL, "");
+
+    //
+    //  Parse any command line options the user may have supplied.
+    //
+    char ch;
 
     while ( ( ch = getopt ( argc, argv, "ab:d:hk:m:?" ) ) != -1 )
     {
@@ -95,45 +95,45 @@ int main ( int argc, char* const argv[] )
 
             break;
 
-		  //
-		  //	Get the requested list count.
-		  //
-		  case 'b':
-		    listsToDump = atol ( optarg );
-			if ( listsToDump <= 0 )
-			{
-				printf ( "Invalid list count[%lu] specified.\n", listsToDump );
-				usage ( argv[0] );
-				exit (255);
-			}
-			break;
+          //
+          //  Get the requested list count.
+          //
+          case 'b':
+            listsToDump = atol ( optarg );
+            if ( listsToDump <= 0 )
+            {
+                printf ( "Invalid list count[%lu] specified.\n", listsToDump );
+                usage ( argv[0] );
+                exit (255);
+            }
+            break;
 
-		  //
-		  //	Get the requested domain value.
-		  //
-		  case 'd':
-		    // domain = atol ( optarg );
-			break;
+          //
+          //  Get the requested domain value.
+          //
+          case 'd':
+            // domain = atol ( optarg );
+            break;
 
-		  //
-		  //	Get the requested key value.
-		  //
-		  case 'k':
-		    // key = atol ( optarg );
-			break;
+          //
+          //  Get the requested key value.
+          //
+          case 'k':
+            // key = atol ( optarg );
+            break;
 
-		  //
-		  //	Get the requested message count.
-		  //
-		  case 'm':
-		    messagesToDump = atol ( optarg );
-			if ( messagesToDump <= 0 )
-			{
-				printf ( "Invalid message count[%lu] specified.\n", messagesToDump );
-				usage ( argv[0] );
-				exit (255);
-			}
-			break;
+          //
+          //  Get the requested message count.
+          //
+          case 'm':
+            messagesToDump = atol ( optarg );
+            if ( messagesToDump <= 0 )
+            {
+                printf ( "Invalid message count[%lu] specified.\n", messagesToDump );
+                usage ( argv[0] );
+                exit (255);
+            }
+            break;
 
           //
           //    Display the help message.
@@ -146,10 +146,10 @@ int main ( int argc, char* const argv[] )
         }
     }
     //
-	//	If the user supplied any arguments other than the buffer size value,
-	//	they are not valid arguments so complain and quit.
+    //  If the user supplied any arguments other than the buffer size value,
+    //  they are not valid arguments so complain and quit.
     //
-	argc -= optind;
+    argc -= optind;
     if ( argc != 0 )
     {
         printf ( "Invalid parameters[s] encountered: %s\n", argv[argc] );
@@ -216,9 +216,9 @@ int main ( int argc, char* const argv[] )
     printf ( "\nAfter all of the frees...\n" );
     dumpSM();
 
-	//
-	//	Return a good completion code to the caller.
-	//
+    //
+    //  Return a good completion code to the caller.
+    //
     return 0;
 }
 

--- a/core/tests/writeRecord.c
+++ b/core/tests/writeRecord.c
@@ -8,9 +8,9 @@
 
 /*!----------------------------------------------------------------------------
 
-	@file writeRecord.c
+    @file writeRecord.c
 
-	This file will write a single record into the shared memory message buffers.
+    This file will write a single record into the shared memory message buffers.
 
 -----------------------------------------------------------------------------*/
 
@@ -28,7 +28,7 @@
 /*! @{ */
 
 //
-//	Define the usage message function.
+//  Define the usage message function.
 //
 static void usage ( const char* executable )
 {
@@ -37,10 +37,10 @@ Usage: %s options\n\
 \n\
   Option     Meaning       Type     Default   \n\
   ======  ==============  ======  =========== \n\
-	-a    ASCII Body      string      None    \n\
-	-b    Body Data       long    Same as key \n\
-	-d    Domain Value     int        CAN     \n\
-	-k    Key Value        int         0	  \n\
+    -a    ASCII Body      string      None    \n\
+    -b    Body Data       long    Same as key \n\
+    -d    Domain Value     int        CAN     \n\
+    -k    Key Value        int         0      \n\
     -h    Help Message     N/A        N/A     \n\
     -?    Help Message     N/A        N/A     \n\
 \n\n\
@@ -51,86 +51,86 @@ Usage: %s options\n\
 
 /*!-----------------------------------------------------------------------
 
-	m a i n
+    m a i n
 
-	@brief The main entry point for this compilation unit.
+    @brief The main entry point for this compilation unit.
 
-	This function will insert a single message into the shared memory segment
-	as specified by the user.
+    This function will insert a single message into the shared memory segment
+    as specified by the user.
 
-	The "domain" will default to "CAN" if not specified by the caller and the
-	"key" value will default to 0.  The body data (8 bytes) will default to
-	the same thing as the key if not specified.
+    The "domain" will default to "CAN" if not specified by the caller and the
+    "key" value will default to 0.  The body data (8 bytes) will default to
+    the same thing as the key if not specified.
 
-	Note that the "body" data will be interpreted as a numeric value unless
-	the user has specified the "ascii" option, in which case up to 8 bytes of
-	ascii will be copied from the command line into the data portion of the
-	generated message.
+    Note that the "body" data will be interpreted as a numeric value unless
+    the user has specified the "ascii" option, in which case up to 8 bytes of
+    ascii will be copied from the command line into the data portion of the
+    generated message.
 
-	If the user specifies both the numeric and ASCII forms of body data, the
-	ASCII data will be used.
+    If the user specifies both the numeric and ASCII forms of body data, the
+    ASCII data will be used.
 
-	@return  0 - This function completed without errors
-	@return !0 - The error code that was encountered
+    @return  0 - This function completed without errors
+    @return !0 - The error code that was encountered
 
 ------------------------------------------------------------------------*/
 int main ( int argc, char* const argv[] )
 {
-	//
-	//	The following locale settings will allow the use of the comma
-	//	"thousands" separator format specifier to be used.  e.g. "10000"
-	//	will print as "10,000" (using the %'u spec.).
-	//
-	setlocale ( LC_ALL, "");
+    //
+    //  The following locale settings will allow the use of the comma
+    //  "thousands" separator format specifier to be used.  e.g. "10000"
+    //  will print as "10,000" (using the %'u spec.).
+    //
+    setlocale ( LC_ALL, "");
 
     //
-    //	Parse any command line options the user may have supplied.
+    //  Parse any command line options the user may have supplied.
     //
-	char asciiData[9] = { 0 };
-	unsigned long numericData = 0;
-	unsigned long keyValue = 0;
-	domain_t domainValue = DOMAIN_CAN;
-	char ch;
-	bool numericDataSupplied = false;
+    char asciiData[9] = { 0 };
+    unsigned long numericData = 0;
+    unsigned long keyValue = 0;
+    domain_t domainValue = DOMAIN_CAN;
+    char ch;
+    bool numericDataSupplied = false;
 
     while ( ( ch = getopt ( argc, argv, "a:b:d:k:h?" ) ) != -1 )
     {
         switch ( ch )
         {
-		  //
-		  //	Get the "copy" ASCII flag if the user specified it.
-		  //
-		  case 'a':
-		    strncpy ( asciiData, optarg, 8 );
-			LOG ( "ASCII body data[%s] will be used.\n", asciiData );
-			break;
+          //
+          //  Get the "copy" ASCII flag if the user specified it.
+          //
+          case 'a':
+            strncpy ( asciiData, optarg, 8 );
+            LOG ( "ASCII body data[%s] will be used.\n", asciiData );
+            break;
 
-		  //
-		  //	Get the body data from the user.
-		  //
-		  case 'b':
-		    numericData = atol ( optarg );
-			LOG ( "Numeric body data[%'lu] will be used.\n", numericData );
-			numericDataSupplied = true;
-			break;
+          //
+          //  Get the body data from the user.
+          //
+          case 'b':
+            numericData = atol ( optarg );
+            LOG ( "Numeric body data[%'lu] will be used.\n", numericData );
+            numericDataSupplied = true;
+            break;
 
-		  //
-		  //	Get the requested domain value.
-		  //
-		  case 'd':
-		    domainValue = atol ( optarg );
-			LOG ( "Using domain value[%'lu]\n", domainValue );
-			break;
-		  //
-		  //	Get the requested key value.
-		  //
-		  case 'k':
-		    keyValue = atol ( optarg );
-			LOG ( "Using key value[%'lu]\n", keyValue );
-			break;
-		  //
-		  //	Display the help message.
-		  //
+          //
+          //  Get the requested domain value.
+          //
+          case 'd':
+            domainValue = atol ( optarg );
+            LOG ( "Using domain value[%'lu]\n", domainValue );
+            break;
+          //
+          //  Get the requested key value.
+          //
+          case 'k':
+            keyValue = atol ( optarg );
+            LOG ( "Using key value[%'lu]\n", keyValue );
+            break;
+          //
+          //  Display the help message.
+          //
           case 'h':
           case '?':
           default:
@@ -139,53 +139,53 @@ int main ( int argc, char* const argv[] )
         }
     }
     //
-	//	If the user supplied any arguments not parsed above, they are not
-	//	valid arguments so complain and quit.
+    //  If the user supplied any arguments not parsed above, they are not
+    //  valid arguments so complain and quit.
     //
-	argc -= optind;
+    argc -= optind;
     if ( argc != 0 )
     {
         printf ( "Invalid parameters[s] encountered: %s\n", argv[argc] );
         usage ( argv[0] );
         exit (255);
     }
-	//
-	//	Open the shared memory file.
-	//
-	//	Note that if the shared memory segment does not already exist, this
-	//	call will create it.
-	//
-	//  TODO: switch this to "false" for production.
-	vsi_core_open ( false );
+    //
+    //  Open the shared memory file.
+    //
+    //  Note that if the shared memory segment does not already exist, this
+    //  call will create it.
+    //
+    //  TODO: switch this to "false" for production.
+    vsi_core_open ( false );
 
-	//
-	//	Go insert this message into the message pool.
-	//
-	//	Note that for these tests, all of the messsages in the message
-	//	pool will be inserted in the "CAN" domain.
-	//
-	if ( strlen ( asciiData ) != 0 )
-	{
-		vsi_core_insert ( domainValue, keyValue, 8, &asciiData );
-	}
-	else
-	{
-		if ( ! numericDataSupplied )
-		{
-			numericData = keyValue;
-		}
-		vsi_core_insert ( domainValue, keyValue, 8, &numericData );
-	}
+    //
+    //  Go insert this message into the message pool.
+    //
+    //  Note that for these tests, all of the messsages in the message
+    //  pool will be inserted in the "CAN" domain.
+    //
+    if ( strlen ( asciiData ) != 0 )
+    {
+        vsi_core_insert ( domainValue, keyValue, 8, &asciiData );
+    }
+    else
+    {
+        if ( ! numericDataSupplied )
+        {
+            numericData = keyValue;
+        }
+        vsi_core_insert ( domainValue, keyValue, 8, &numericData );
+    }
     dumpAllSignals( 0 );
 
-	//
-	//	Close our shared memory segment and exit.
-	//
-	vsi_core_close();
+    //
+    //  Close our shared memory segment and exit.
+    //
+    vsi_core_close();
 
-	//
-	//	Return a good completion code to the caller.
-	//
+    //
+    //  Return a good completion code to the caller.
+    //
     return 0;
 }
 

--- a/core/utils.c
+++ b/core/utils.c
@@ -8,14 +8,14 @@
 
 /*!----------------------------------------------------------------------------
 
-	@file      utils.c
+    @file      utils.c
 
-	This file contains the utility functions that are used by various parts of
-	the main shared memory test code.
+    This file contains the utility functions that are used by various parts of
+    the main shared memory test code.
 
-	There are dump functions defined here that can be called by the code
-	during debugging to gain insight into the state and structure of the
-	various shared memory segment data structures.
+    There are dump functions defined here that can be called by the code
+    during debugging to gain insight into the state and structure of the
+    various shared memory segment data structures.
 
 -----------------------------------------------------------------------------*/
 
@@ -34,11 +34,11 @@
 /*! @{ */
 
 //
-//	WARNING!!!: All references (and pointers) to data in the VSI signal buffer
-//	are performed by using the offset from the shared memory segment base
-//	address.  All of these references need to be relocatable references so
-//	this will work in multiple processes that have their shared memory
-//	segments mapped to different base addresses.
+//  WARNING!!!: All references (and pointers) to data in the VSI signal buffer
+//  are performed by using the offset from the shared memory segment base
+//  address.  All of these references need to be relocatable references so
+//  this will work in multiple processes that have their shared memory
+//  segments mapped to different base addresses.
 //
 
 
@@ -47,22 +47,22 @@
 
     d u m p A l l S i g n a l s
 
-	@brief Dump all of the signals currently defined.
+    @brief Dump all of the signals currently defined.
 
-	This function will dump all of the signals currently defined.  It
+    This function will dump all of the signals currently defined.  It
     traverses all of the signal lists and dumps them in the order in which
     they are found.  This order is determined by the comparison function
     defined for the signal list B-tree (usually the domain & ID of the
     signal).
 
-	@param[in] maxSignals - The maximum number of signals to dump per list.
+    @param[in] maxSignals - The maximum number of signals to dump per list.
 
-	@return None
+    @return None
 
 -----------------------------------------------------------------------------*/
 void dumpAllSignals ( int maxSignals )
 {
-	signalList_t* signals;
+    signalList_t* signals;
 
     //
     //  If the system has not finished initializing yet, just ignore this call.
@@ -72,17 +72,17 @@ void dumpAllSignals ( int maxSignals )
         return;
     }
 
-	btree_iter iter = btree_iter_begin ( &smControl->signals );
+    btree_iter iter = btree_iter_begin ( &smControl->signals );
 
-	while ( ! btree_iter_at_end ( iter ) )
-	{
-		signals = btree_iter_data ( iter );
+    while ( ! btree_iter_at_end ( iter ) )
+    {
+        signals = btree_iter_data ( iter );
 
-		dumpSignalList ( signals, maxSignals );
+        dumpSignalList ( signals, maxSignals );
 
-		btree_iter_next ( iter );
-	}
-	btree_iter_cleanup ( iter );
+        btree_iter_next ( iter );
+    }
+    btree_iter_cleanup ( iter );
 
     return;
 }
@@ -93,15 +93,15 @@ void dumpAllSignals ( int maxSignals )
 
     d u m p S i g n a l L i s t
 
-	@brief Dump the contents of the specified signal list.
+    @brief Dump the contents of the specified signal list.
 
-	This function will Dump the contents of a single signal list.  This will
-	also dump the individual signals contained in this list.
+    This function will Dump the contents of a single signal list.  This will
+    also dump the individual signals contained in this list.
 
-	@param[in] signalList - The address of the signal list to be dumped
-	@param[in] maxSignals - The maximum number of signals to display in each
-	                         signal list.
-	@return None
+    @param[in] signalList - The address of the signal list to be dumped
+    @param[in] maxSignals - The maximum number of signals to display in each
+                            signal list.
+    @return None
 
 ------------------------------------------------------------------------*/
 void dumpSignalList ( signalList_t* signalList, int maxSignals )
@@ -113,70 +113,70 @@ void dumpSignalList ( signalList_t* signalList, int maxSignals )
     {
         return;
     }
-	//
-	//	If there are some signals in this signal list...
-	//
-	if ( signalList->currentSignalCount > 0 )
-	{
-		//
-        //	Display the address of this signal list and it's offset within the
-        //	shared memory segment.
-		//
-		LOG ( "Signal List %p[0x%lx]:\n", signalList, toOffset ( signalList ) );
+    //
+    //  If there are some signals in this signal list...
+    //
+    if ( signalList->currentSignalCount > 0 )
+    {
+        //
+        //  Display the address of this signal list and it's offset within the
+        //  shared memory segment.
+        //
+        LOG ( "Signal List %p[0x%lx]:\n", signalList, toOffset ( signalList ) );
 
-		//
-		//	If the head offset indicates that this is the end of the signal
-		//	list, display a signal saying we hit the end of the list.
-		//
-		if ( signalList->head == END_OF_LIST_MARKER )
-		{
-			LOG ( "Head offset............: End of List Marker\n" );
-		}
-		//
-		//	Otherwise, display the head offset value.  This is the offset in
-		//	the segment of the first data signal record.
-		//
-		else
-		{
-			LOG ( "Head offset............: 0x%lx[%lu]\n", signalList->head,
+        //
+        //  If the head offset indicates that this is the end of the signal
+        //  list, display a signal saying we hit the end of the list.
+        //
+        if ( signalList->head == END_OF_LIST_MARKER )
+        {
+            LOG ( "Head offset............: End of List Marker\n" );
+        }
+        //
+        //  Otherwise, display the head offset value.  This is the offset in
+        //  the segment of the first data signal record.
+        //
+        else
+        {
+            LOG ( "Head offset............: 0x%lx[%lu]\n", signalList->head,
                   signalList->head );
-		}
-		//
-		//	If the tail offset indicates that this is the end of the signal
-		//	list, display a signal saying we hit the end of the list.
-		//
-		if ( signalList->tail == END_OF_LIST_MARKER )
-		{
-			LOG ( "Tail offset............: End of List Marker\n" );
-		}
-		//
-		//	Otherwise, display the tail offset value.  This is the offset in
-		//	the segment of the start of the last data signal record.
-		//
-		else
-		{
-			LOG ( "Tail offset............: 0x%lx[%lu]\n", signalList->tail,
+        }
+        //
+        //  If the tail offset indicates that this is the end of the signal
+        //  list, display a signal saying we hit the end of the list.
+        //
+        if ( signalList->tail == END_OF_LIST_MARKER )
+        {
+            LOG ( "Tail offset............: End of List Marker\n" );
+        }
+        //
+        //  Otherwise, display the tail offset value.  This is the offset in
+        //  the segment of the start of the last data signal record.
+        //
+        else
+        {
+            LOG ( "Tail offset............: 0x%lx[%lu]\n", signalList->tail,
                   signalList->tail );
-		}
-		//
-		//	Display the number of messages currently stored in this hash
-		//	bucket.
-		//
-		LOG ( "Message count..........: %'lu\n", signalList->currentSignalCount );
+        }
+        //
+        //  Display the number of messages currently stored in this hash
+        //  bucket.
+        //
+        LOG ( "Message count..........: %'lu\n", signalList->currentSignalCount );
 
-		//
-        //	Display the number of bytes of memory that have been allocated to
-        //	this signal list for the storage of signals.
-		//
-		LOG ( "Total signal size......: %lu[0x%lx]\n", signalList->totalSignalSize,
+        //
+        //  Display the number of bytes of memory that have been allocated to
+        //  this signal list for the storage of signals.
+        //
+        LOG ( "Total signal size......: %lu[0x%lx]\n", signalList->totalSignalSize,
               signalList->totalSignalSize );
 
-		//
-		//	Go dump the contents of the signal list in this entry.
-		//
-		dumpSignals ( signalList, maxSignals );
-	}
-	return;
+        //
+        //  Go dump the contents of the signal list in this entry.
+        //
+        dumpSignals ( signalList, maxSignals );
+    }
+    return;
 }
 
 
@@ -184,15 +184,15 @@ void dumpSignalList ( signalList_t* signalList, int maxSignals )
 
     d u m p S i g n a l s
 
-	@brief Dump the contents of the specified shared memory signal list.
+    @brief Dump the contents of the specified shared memory signal list.
 
     This function will dump all of the signals in the specified signals list.
     The actual binary contents of each message is also dumped.
 
-	@param[in] signalList - The address of the signalList to be dumped.
-	@param[in] maxSignals - The maximum number of signals to dump for this
-							 signal list.
-	@return None
+    @param[in] signalList - The address of the signalList to be dumped.
+    @param[in] maxSignals - The maximum number of signals to dump for this
+                            signal list.
+    @return None
 
 ------------------------------------------------------------------------*/
 void dumpSignals ( signalList_t* signalList, int maxSignals )
@@ -228,104 +228,104 @@ void dumpSignals ( signalList_t* signalList, int maxSignals )
     {
         return;
     }
-	//
-	//	Get an actual pointer to the first signal in this list.  This is
-	//	the signal that is pointed to by the "head" offset.
-	//
-	signalData_t* signal = toAddress ( signalOffset );
+    //
+    //  Get an actual pointer to the first signal in this list.  This is
+    //  the signal that is pointed to by the "head" offset.
+    //
+    signalData_t* signal = toAddress ( signalOffset );
 
     //
-    //	Display the signal list address.
+    //  Display the signal list address.
     //
     LOG ( "    Signal list [%p]:\n", signalList );
 
     //
-    //	Display the domain associated with this signal.
+    //  Display the domain associated with this signal.
     //
     LOG ( "      Domain: %'lu\n", signalList->domain );
 
     //
-    //	Display the key value that was associated with this signal.
+    //  Display the key value that was associated with this signal.
     //
     LOG ( "      Key:    %'lu\n", signalList->key );
 
-	//
-	//	Repeat until we reach the end of the signal list in this bucket.
-	//
-	while ( signalOffset != END_OF_LIST_MARKER )
-	{
-		//
-		//	Display the size of this signal in bytes.
-		//
-		LOG ( "      %'d - Signal data size...: %'lu\n", ++i, signal->messageSize );
+    //
+    //  Repeat until we reach the end of the signal list in this bucket.
+    //
+    while ( signalOffset != END_OF_LIST_MARKER )
+    {
+        //
+        //  Display the size of this signal in bytes.
+        //
+        LOG ( "      %'d - Signal data size...: %'lu\n", ++i, signal->messageSize );
 
-		//
-		//	If the "next" signal offset indicates that this is the end of the
-		//	signal list, display a message saying we hit the end of the list.
-		//
+        //
+        //  If the "next" signal offset indicates that this is the end of the
+        //  signal list, display a message saying we hit the end of the list.
+        //
         signalOffset = signal->nextMessageOffset;
-		if ( signalOffset == END_OF_LIST_MARKER )
-		{
-			LOG ( "      Next signal offset.: End of List Marker\n" );
-		}
-		//
-        //	Otherwise, display the next signal offset value.  This is the
-        //	offset in the signal list where the next logical signal in the
-        //	list is located.
-		//
-		else
-		{
-			LOG ( "       Next signal offset.: %'lu\n", signalOffset );
-		}
-		//
-		//	Go dump the contents of the data field for this signal.
-		//
-		HexDump ( signal->data, signal->messageSize, "Signal Data", 6 );
+        if ( signalOffset == END_OF_LIST_MARKER )
+        {
+            LOG ( "      Next signal offset.: End of List Marker\n" );
+        }
+        //
+        //  Otherwise, display the next signal offset value.  This is the
+        //  offset in the signal list where the next logical signal in the
+        //  list is located.
+        //
+        else
+        {
+            LOG ( "       Next signal offset.: %'lu\n", signalOffset );
+        }
+        //
+        //  Go dump the contents of the data field for this signal.
+        //
+        HexDump ( signal->data, signal->messageSize, "Signal Data", 6 );
 
         //
         //  If we have reached the maximum number of signals the caller asked
         //  us to disply, break out of this loop and quit.
         //
-		if ( --maxSignals == 0 )
-		{
-			break;
-		}
-		//
-		//	Get the address of where the next signal in the list is located.
-		//
+        if ( --maxSignals == 0 )
+        {
+            break;
+        }
+        //
+        //  Get the address of where the next signal in the list is located.
+        //
         signal = toAddress ( signalOffset );
-	}
-	return;
+    }
+    return;
 }
 
 
 /*!-----------------------------------------------------------------------
 
-	d u m p S e m a p h o r e
+    d u m p S e m a p h o r e
 
-	@brief Dump the fields of a semaphore.
+    @brief Dump the fields of a semaphore.
 
-	This function will dump all of the fields of the specified semaphore that
-	make sense.  The mutex and condition variable are not dumped as we have no
-	explicit information about what is inside them.
+    This function will dump all of the fields of the specified semaphore that
+    make sense.  The mutex and condition variable are not dumped as we have no
+    explicit information about what is inside them.
 
-	@param[in] semaphore - The address of the semaphore to be dumped.
+    @param[in] semaphore - The address of the semaphore to be dumped.
 
 ------------------------------------------------------------------------*/
 void dumpSemaphore ( semaphore_p semaphore )
 {
 #ifdef DUMP_SEMAPHORE
-	LOG ( "semaphore: %3p\n", (void*)((long)&semaphore->mutex % 0x1000 ) );
+    LOG ( "semaphore: %3p\n", (void*)((long)&semaphore->mutex % 0x1000 ) );
 
-	//
-	//	Display our count values.
-	//
-	LOG ( "   message count.........: %'d\n", semaphore->messageCount );
-	LOG ( "   waiter count..........: %'d\n", semaphore->waiterCount );
+    //
+    //  Display our count values.
+    //
+    LOG ( "   message count.........: %'d\n", semaphore->messageCount );
+    LOG ( "   waiter count..........: %'d\n", semaphore->waiterCount );
 
-	//
-	//	Display the semaphore data...
-	//
+    //
+    //  Display the semaphore data...
+    //
     LOG ( "   semaphore.mutex.lock..: %d\n", semaphore->mutex.__data.__lock );
     LOG ( "   semaphore.mutex.count.: %d\n", semaphore->mutex.__data.__count );
     LOG ( "   semaphore.mutex.owner.: %d\n", semaphore->mutex.__data.__owner );
@@ -333,7 +333,7 @@ void dumpSemaphore ( semaphore_p semaphore )
     LOG ( "   semaphore.mutex.kind..: %d\n", semaphore->mutex.__data.__kind );
 
 #endif
-	return;
+    return;
 }
 
 
@@ -348,15 +348,15 @@ void dumpSemaphore ( semaphore_p semaphore )
     0016   67 4C 65 76 65 6C 3A 00 98                       gLevel:..
 
     Note that the input does not need to be a string, just an array of bytes.
-	The dump will be output with 16 bytes per line and have the ASCII
-	representation of the data appended to each line.  Unprintable characters
-	are printed as a period.
+    The dump will be output with 16 bytes per line and have the ASCII
+    representation of the data appended to each line.  Unprintable characters
+    are printed as a period.
 
-	The title, outputWidth, and leadingSpaces are optional arguments that can
-	be left off by using one of the helper macros.
+    The title, outputWidth, and leadingSpaces are optional arguments that can
+    be left off by using one of the helper macros.
 
-	The output from calling this function will be generated on the "stdout"
-	device.
+    The output from calling this function will be generated on the "stdout"
+    device.
 
     The maximum length of a hex dump is specified by the constant below and
     all dumps will be truncated to this length if they are longer than this
@@ -366,7 +366,7 @@ void dumpSemaphore ( semaphore_p semaphore )
 
         HexDump ( data, length, "Title", 0 );
 
-	or in this case:
+    or in this case:
 
         HEX_DUMP_TL ( data, length, "Title", 0 );
 
@@ -375,8 +375,8 @@ void dumpSemaphore ( semaphore_p semaphore )
         data - The address of the data buffer to be dumped
         length - The number of bytes of data to be dumped
         title - The address of an optional title string for the dump
-		leadingSpaces - The number of spaces to be added at the beginning of
-						each line.
+        leadingSpaces - The number of spaces to be added at the beginning of
+                        each line.
 
     Output Data:  None
 
@@ -394,8 +394,8 @@ void dumpSemaphore ( semaphore_p semaphore )
 #define MAX_DUMP_SIZE ( 1024 )
 
 //
-//	The following macros are defined in the header file to make it easier to
-//	call the HexDump function with various combinations of arguments.
+//  The following macros are defined in the header file to make it easier to
+//  call the HexDump function with various combinations of arguments.
 //
 // #define HEX_DUMP(   data, length )         HexDump ( data, length, "", 0 )
 // #define HEX_DUMP_T( data, length, title )  HexDump ( data, length, title, 0 )
@@ -404,7 +404,7 @@ void dumpSemaphore ( semaphore_p semaphore )
 //
 
 void HexDump ( const char *data, int length, const char *title,
-			   int leadingSpaces )
+               int leadingSpaces )
 {
     unsigned char c;
     int           i;
@@ -413,10 +413,10 @@ void HexDump ( const char *data, int length, const char *title,
     int           outputWidth      = 16;
     int           currentLineWidth = 0;
     int           originalLength   = 0;
-	char          asciiString[400] = { 0 };
+    char          asciiString[400] = { 0 };
 
-	XPRINT ( "data(%d): \"%s\", title: %p, width: %d, spaces: %d\n", length,
-			 data, title, outputWidth, leadingSpaces );
+    XPRINT ( "data(%d): \"%s\", title: %p, width: %d, spaces: %d\n", length,
+             data, title, outputWidth, leadingSpaces );
     //
     //    If the length field is unreasonably long, truncate it.
     //
@@ -431,18 +431,18 @@ void HexDump ( const char *data, int length, const char *title,
     //
     //    Output the leader string at the beginning of the title line.
     //
-	for ( i = 0; i < leadingSpaces; i++ )
-	{
-		putchar ( ' ' );
-	}
+    for ( i = 0; i < leadingSpaces; i++ )
+    {
+        putchar ( ' ' );
+    }
     //
     //    If the user specified a title for the dump, output that title
     //    followed by the buffer size and location.
     //
     if ( title != NULL && strlen(title) != 0 )
     {
-		fputs ( title, stdout );
-		printf ( " (%d bytes @ %p):\n", originalLength, data );
+        fputs ( title, stdout );
+        printf ( " (%d bytes @ %p):\n", originalLength, data );
     }
     //
     //    If the user did not specify a title for the dump, just output the
@@ -450,7 +450,7 @@ void HexDump ( const char *data, int length, const char *title,
     //
     else
     {
-		printf ( "%d bytes @ %p:\n", originalLength, data );
+        printf ( "%d bytes @ %p:\n", originalLength, data );
     }
     //
     //    For each byte in the data to be dumped...
@@ -476,29 +476,29 @@ void HexDump ( const char *data, int length, const char *title,
             //
             if ( i > 0 )
             {
-				asciiString[s] = 0;
-				puts ( asciiString );
+                asciiString[s] = 0;
+                puts ( asciiString );
 
                 asciiString[0] = 0;
-				s = 0;
+                s = 0;
             }
             //
             //    Output the leader string at the beginning of the new line.
             //
-			for ( j = 0; j < leadingSpaces; j++ )
-			{
-				putchar ( ' ' );
-			}
+            for ( j = 0; j < leadingSpaces; j++ )
+            {
+                putchar ( ' ' );
+            }
             //
             //    Output the data offset field for this new line.
             //
-			printf ( "%06d  ", i );
+            printf ( "%06d  ", i );
         }
         //
         //    Generate the hex representation for the current data character.
         //
         c = *data++;
-		printf ( "%02x ", c );
+        printf ( "%02x ", c );
 
         //
         //    Generate the ASCII representation of the data character at this
@@ -507,11 +507,11 @@ void HexDump ( const char *data, int length, const char *title,
         //
         if ( c >= ' ' && c <= '~' )
         {
-			asciiString[s++] = c;
+            asciiString[s++] = c;
         }
         else
         {
-			asciiString[s++] = '.';
+            asciiString[s++] = '.';
         }
         //
         //    Increment the width of the line generated so far.
@@ -527,13 +527,13 @@ void HexDump ( const char *data, int length, const char *title,
     //
     for ( i = 0; i < outputWidth - currentLineWidth; i++ )
     {
-		fputs ( "   ", stdout );
+        fputs ( "   ", stdout );
     }
     //
     //    Output the last line of the display.
     //
-	asciiString[s] = 0;
-	puts ( asciiString );
+    asciiString[s] = 0;
+    puts ( asciiString );
 
     //
     //    If the original length was truncated because it was unreasonably
@@ -541,7 +541,7 @@ void HexDump ( const char *data, int length, const char *title,
     //
     if ( originalLength > length )
     {
-		printf ( "       ...Dump of %d bytes has been truncated\n", originalLength );
+        printf ( "       ...Dump of %d bytes has been truncated\n", originalLength );
     }
     //
     //    Return to the caller.
@@ -552,13 +552,13 @@ void HexDump ( const char *data, int length, const char *title,
 #ifdef VSI_DEBUG
 
 //
-//	TODO: The following function is for debugging purposes.
+//  TODO: The following function is for debugging purposes.
 //
-//	This function will return the time in microseconds since the shared memory
-//	segment was first accessed after being initialized.  The time is in
-//	microseconds instead of the raw nanosecond form because the nanosecond
-//	portion of the time is not very interesting and just clutters up the
-//	output.
+//  This function will return the time in microseconds since the shared memory
+//  segment was first accessed after being initialized.  The time is in
+//  microseconds instead of the raw nanosecond form because the nanosecond
+//  portion of the time is not very interesting and just clutters up the
+//  output.
 //
 //  The first time this function is called it will set the global base time
 //  contained in the shared memory control block.  All subsequent times are
@@ -569,8 +569,8 @@ void HexDump ( const char *data, int length, const char *title,
 
 unsigned long getIntervalTime ( void )
 {
-	unsigned long currentTime;
-	struct timespec timeSpec;
+    unsigned long currentTime;
+    struct timespec timeSpec;
 
     if ( smControl != 0 )
     {

--- a/core/utils.h
+++ b/core/utils.h
@@ -51,7 +51,7 @@ unsigned long getIntervalTime ( void );
 #endif
 
 
-#endif		// End of #ifndef UTILS_H
+#endif      // End of #ifndef UTILS_H
 
 /*! @} */
 

--- a/core/vsi_core_api.c
+++ b/core/vsi_core_api.c
@@ -44,15 +44,15 @@ static sysMemory_t*    vsi_core_open_sys  ( bool createNew );
 
     v s i _ c o r e _ o p e n
 
-	@brief Open the shared memory segments.
+    @brief Open the shared memory segments.
 
-	This function will
+    This function will
 
-	@param[in]
-	@param[out]
-	@param[in,out]
+    @param[in]
+    @param[out]
+    @param[in,out]
 
-	@return None
+    @return None
 
 -----------------------------------------------------------------------------*/
 void vsi_core_open ( bool createNew )
@@ -211,15 +211,15 @@ static sharedMemory_t* vsi_core_open_user ( bool createNew )
 
     v s i _ c o r e _ o p e n _ s y s
 
-	@brief
+    @brief
 
-	This function will
+    This function will
 
-	@param[in]
-	@param[out]
-	@param[in,out]
+    @param[in]
+    @param[out]
+    @param[in,out]
 
-	@return None
+    @return None
 
 -----------------------------------------------------------------------------*/
 static sysMemory_t* vsi_core_open_sys ( bool createNew )

--- a/core/vsi_core_api.h
+++ b/core/vsi_core_api.h
@@ -71,9 +71,9 @@ typedef void* vsi_core_handle;
     If the VSI core environment does not exist yet, it will be created by this
     call.
 
-	@param[in] - createNew - Create a brand new empty data store.
+    @param[in] - createNew - Create a brand new empty data store.
 
-	@return The handle to the VSI core data store.
+    @return The handle to the VSI core data store.
             NULL indicates an error.
 
 ------------------------------------------------------------------------*/
@@ -84,7 +84,7 @@ void vsi_core_open ( bool createNew );
 
     v s i _ c o r e _ c l o s e
 
-	@brief Close the VSI core environment.
+    @brief Close the VSI core environment.
 
     Note that this call will undo everything that was set up by the "open"
     call.  However, it will not destroy the persistent data created while the
@@ -94,7 +94,7 @@ void vsi_core_open ( bool createNew );
     After calling this function, any access to an item located in the core
     data store will result in a SEGV signal being generated.
 
-	@return None
+    @return None
 
 ------------------------------------------------------------------------*/
 void vsi_core_close ( void );
@@ -104,7 +104,7 @@ void vsi_core_close ( void );
 
     v s i _ c o r e _ i n s e r t
 
-	@brief Insert a message into the VSI core data store.
+    @brief Insert a message into the VSI core data store.
 
     This function will insert a new message into the VSI core data store with
     the given domain and key values.  If there is no space left in the data
@@ -118,7 +118,7 @@ void vsi_core_close ( void );
     @param[in] newMessageSize - The size of the new message in bytes.
     @param[in] body - The address of the body of the new message.
 
-	@return None
+    @return None
 
 ------------------------------------------------------------------------*/
 void vsi_core_insert ( domain_t domain,
@@ -127,9 +127,9 @@ void vsi_core_insert ( domain_t domain,
 
 /*!-----------------------------------------------------------------------
 
-	v s i _ c o r e _ f e t c h
+    v s i _ c o r e _ f e t c h
 
-	@brief Fetch and remove the oldest message from the VSI data store.
+    @brief Fetch and remove the oldest message from the VSI data store.
 
     This function will find the oldest message with the specified domain and
     key values in the VSI data store, return the message data to the caller
@@ -143,7 +143,7 @@ void vsi_core_insert ( domain_t domain,
     @param[in/out] bodySize - The address of the body buffer size.
     @param[out] body - The address of the user's message buffer.
 
-	@return 0      - Success
+    @return 0      - Success
             ENOMSG - The requested domain/key does not exist.
                    - Anything else is an error code.
 
@@ -156,7 +156,7 @@ int vsi_core_fetch ( domain_t domain,
 
     v s i _ c o r e _ f e t c h _ w a i t
 
-	@brief Fetch and remove a message from the VSI data store with wait.
+    @brief Fetch and remove a message from the VSI data store with wait.
 
     This function will find the message with the specified domain and key
     values in the VSI data store, return the message data to the caller and
@@ -173,7 +173,7 @@ int vsi_core_fetch ( domain_t domain,
     @param[in/out] bodySize - The address of the body buffer size.
     @param[out] body - The address of the user's message buffer.
 
-	@return 0 - Success
+    @return 0 - Success
               - Anything else is an error code.
 
 ------------------------------------------------------------------------*/
@@ -186,7 +186,7 @@ int vsi_core_fetch_wait ( domain_t domain,
 
     v s i _ c o r e _ f e t c h _ n e w e s t
 
-	@brief Fetch the newest message from the VSI data store with wait.
+    @brief Fetch the newest message from the VSI data store with wait.
 
     This function will find the newest message with the specified domain and
     key values in the VSI data store and return the message data to the
@@ -200,7 +200,7 @@ int vsi_core_fetch_wait ( domain_t domain,
     @param[in/out] bodySize - The address of the body buffer size.
     @param[out] body - The address of the user's message buffer.
 
-	@return 0 - Success
+    @return 0 - Success
               - Anything else is an error code.
 
 ------------------------------------------------------------------------*/
@@ -213,9 +213,9 @@ int vsi_core_fetch_newest ( domain_t domain,
 
     v s i _ c o r e _ f l u s h _ s i g n a l
 
-	@brief Flush all instances of the specified signal from the data store.
+    @brief Flush all instances of the specified signal from the data store.
 
-	This function will find all of the instances of signals with the specified
+    This function will find all of the instances of signals with the specified
     domain and key and remove them from the data store.  This call is designed
     to allow users to basically reset all of the data associated with a signal
     so the app can start from a known clean point.
@@ -224,7 +224,7 @@ int vsi_core_fetch_newest ( domain_t domain,
     @param[in] domain - The domain associated with this message.
     @param[in] key - The key value associated with this message.
 
-	@return 0 on Success
+    @return 0 on Success
             Anything else is an error code (errno value)
 
 ------------------------------------------------------------------------*/

--- a/lua-interfaces/lua_vsi.c
+++ b/lua-interfaces/lua_vsi.c
@@ -30,9 +30,9 @@
 
     l u a o p e n _ l i b l u a _ v s i
 
-	@brief Register the Lua functions we have implemented here.
+    @brief Register the Lua functions we have implemented here.
 
-	This function will make calls to Lua to register the names of all of the
+    This function will make calls to Lua to register the names of all of the
     functions that have been implemented in this library.
 
 ------------------------------------------------------------------------*/

--- a/lua-interfaces/lua_vsi_api.c
+++ b/lua-interfaces/lua_vsi_api.c
@@ -180,7 +180,7 @@ static int Lua_vsi_destroy ( lua_State* L )
 
     L u a _ v s i _ V S S _ i m p o r t
 
-	@brief Import a VSS file into the VSI data store.
+    @brief Import a VSS file into the VSI data store.
 
     Lua Interface:
 
@@ -193,17 +193,17 @@ static int Lua_vsi_destroy ( lua_State* L )
         Return values:
             Completion code (number)
 
-	This function will read the specified file and import the contents of it
+    This function will read the specified file and import the contents of it
     into the specified VSI environment.
 
     VSI API C Interface:
 
         int vsi_VSS_import ( vsi_handle handle, const char* fileName );
 
-	@param[in] - handle - The VSI context handle
-	@param[in] - fileName - The pathname to the VSS definition file to be read
+    @param[in] - handle - The VSI context handle
+    @param[in] - fileName - The pathname to the VSS definition file to be read
 
-	@return - Completion code - 0 = Succesful
+    @return - Completion code - 0 = Succesful
                                 Anything else is an error code
 
 -----------------------------------------------------------------------------*/
@@ -2022,9 +2022,9 @@ static int Lua_vsi_name_string_to_id ( lua_State* L )
 
     VSI API C Interface:
 
-		int vsi_signal_id_to_string ( const domain_t domainId,
-									  const signal_t signalId,
-									  char**         name );
+        int vsi_signal_id_to_string ( const domain_t domainId,
+                                      const signal_t signalId,
+                                      char**         name );
 
     @param[in] - domainId - The signal domain ID to be converted.
     @param[in] - signalId - The signal ID to be converted.
@@ -2057,7 +2057,7 @@ static int Lua_vsi_signal_id_to_string ( lua_State* L )
 
 /*!-----------------------------------------------------------------------
 
-	L u a _ v s i _ d e f i n e _ s i g n a l _ n a m e
+    L u a _ v s i _ d e f i n e _ s i g n a l _ n a m e
 
     @brief Define new signal Id/Name definition record.
 
@@ -2079,10 +2079,10 @@ static int Lua_vsi_signal_id_to_string ( lua_State* L )
 
     VSI API C Interface:
 
-		int vsi_define_signal_name ( const domain_t domainId,
-									 const signal_t signalId,
-									 const signal_t privateId,
-									 const char*    name );
+        int vsi_define_signal_name ( const domain_t domainId,
+                                     const signal_t signalId,
+                                     const signal_t privateId,
+                                     const char*    name );
 
     @param[in] domainId - The signal domain ID to be defined.
     @param[in] signalId - The signal ID to be defined.
@@ -2109,9 +2109,9 @@ static int Lua_vsi_define_signal_name ( lua_State* L )
 
     l u a o p e n _ l i b l u a _ v s i _ a p i
 
-	@brief Register the Lua functions we have implemented here.
+    @brief Register the Lua functions we have implemented here.
 
-	This function will make calls to Lua to register the names of all of the
+    This function will make calls to Lua to register the names of all of the
     functions that have been implemented in this library.
 
 ------------------------------------------------------------------------*/

--- a/lua-interfaces/lua_vsi_core.c
+++ b/lua-interfaces/lua_vsi_core.c
@@ -76,9 +76,9 @@ static vsi_core_handle handle = 0;
 
         vsi_core_handle vsi_core_open ( void );
 
-	@param  None
+    @param  None
 
-	@return The handle to the VSI core data store.
+    @return The handle to the VSI core data store.
             NULL indicates an error.
 
 ------------------------------------------------------------------------*/
@@ -130,7 +130,7 @@ static int Lua_vsiCoreOpen ( lua_State* L )
 
     L u a _ v s i C o r e C l o s e
 
-	@brief Close the VSI core environment.
+    @brief Close the VSI core environment.
 
     Lua Interface:
 
@@ -150,9 +150,9 @@ static int Lua_vsiCoreOpen ( lua_State* L )
 
         void vsi_core_close ( vsi_core_handle handle );
 
-	@param[in] handle - The VSI data store handle.
+    @param[in] handle - The VSI data store handle.
 
-	@return None
+    @return None
 
 ------------------------------------------------------------------------*/
 static int Lua_vsiCoreClose ( lua_State* L )
@@ -178,7 +178,7 @@ static int Lua_vsiCoreClose ( lua_State* L )
 
     L u a _ v s i C o r e I n s e r t
 
-	@brief Insert a message into the VSI core data store.
+    @brief Insert a message into the VSI core data store.
 
     Lua Interface:
 
@@ -209,7 +209,7 @@ static int Lua_vsiCoreClose ( lua_State* L )
     @param[in] newMessageSize - The size of the new message in bytes.
     @param[in] body - The address of the body of the new message.
 
-	@return None
+    @return None
 
 ------------------------------------------------------------------------*/
 static int Lua_vsiCoreInsert ( lua_State* L )
@@ -237,7 +237,7 @@ static int Lua_vsiCoreInsert ( lua_State* L )
 
     L u a _ v s i C o r e F e t c h
 
-	@brief Fetch and remove the oldest message from the VSI data store.
+    @brief Fetch and remove the oldest message from the VSI data store.
 
     Lua Interface:
 
@@ -267,7 +267,7 @@ static int Lua_vsiCoreInsert ( lua_State* L )
     @param[in/out] bodySize - The address of the body buffer size.
     @param[out] body - The address of the user's message buffer.
 
-	@return 0      - Success
+    @return 0      - Success
             ENOMSG - The requested domain/key does not exist.
                    - Anything else is an error code.
 
@@ -293,7 +293,7 @@ static int Lua_vsiCoreFetch ( lua_State* L )
 
     L u a _ v s i C o r e F e t c h W a i t
 
-	@brief Fetch and remove a message from the VSI data store with wait.
+    @brief Fetch and remove a message from the VSI data store with wait.
 
     Lua Interface:
 
@@ -326,7 +326,7 @@ static int Lua_vsiCoreFetch ( lua_State* L )
     @param[in/out] bodySize - The address of the body buffer size.
     @param[out] body - The address of the user's message buffer.
 
-	@return 0 - Success
+    @return 0 - Success
               - Anything else is an error code.
 
 ------------------------------------------------------------------------*/
@@ -351,7 +351,7 @@ static int Lua_vsiCoreFetchWait ( lua_State* L )
 
     L u a _ v s i C o r e F e t c h N e w e s t
 
-	@brief Fetch the newest message from the VSI data store with wait.
+    @brief Fetch the newest message from the VSI data store with wait.
 
     Lua Interface:
 
@@ -382,7 +382,7 @@ static int Lua_vsiCoreFetchWait ( lua_State* L )
     @param[in/out] bodySize - The address of the body buffer size.
     @param[out] body - The address of the user's message buffer.
 
-	@return 0 - Success
+    @return 0 - Success
               - Anything else is an error code.
 
 ------------------------------------------------------------------------*/
@@ -407,7 +407,7 @@ static int Lua_vsiCoreFetchNewest ( lua_State* L )
 
     L u a _ v s i C o r e F l u s h S i g n a l
 
-	@brief Flush all instances of the specified signal from the data store.
+    @brief Flush all instances of the specified signal from the data store.
 
     Lua Interface:
 
@@ -419,7 +419,7 @@ static int Lua_vsiCoreFetchNewest ( lua_State* L )
         status - the completion status of the operation (0 == successful).
 
     This function will find the message with the specified domain and key
-	This function will find all of the instances of signals with the specified
+    This function will find all of the instances of signals with the specified
     domain and key and remove them from the data store.  This call is designed
     to allow users to basically reset all of the data associated with a signal
     so the app can start from a known clean point.
@@ -431,7 +431,7 @@ static int Lua_vsiCoreFetchNewest ( lua_State* L )
     @param[in] domain - The domain associated with this message.
     @param[in] key - The key value associated with this message.
 
-	@return 0 on Success
+    @return 0 on Success
             Anything else is an error code (errno value)
 
 ------------------------------------------------------------------------*/
@@ -452,9 +452,9 @@ static int Lua_vsiCoreFlushSignal ( lua_State* L )
 
     l u a o p e n _ l i b l u a _ v s i _ c o r e
 
-	@brief Register the Lua functions we have implemented here.
+    @brief Register the Lua functions we have implemented here.
 
-	This function will make calls to Lua to register the names of all of the
+    This function will make calls to Lua to register the names of all of the
     functions that have been implemented in this library.
 
 ------------------------------------------------------------------------*/

--- a/python-interfaces/vsi_py.c
+++ b/python-interfaces/vsi_py.c
@@ -54,14 +54,14 @@ static PyMethodDef VsiMethods[] =
 
     P y I n i t _ p y V s i
 
-	@brief Initialize the Python interface to the VSI system.
+    @brief Initialize the Python interface to the VSI system.
 
     This function will initialize the Python interface to the VSI system and
     MUST be called before any other VSI functions are called.
 
-	@param[in]  None
+    @param[in]  None
 
-	@return 0 - Error occurred (exception thrown)
+    @return 0 - Error occurred (exception thrown)
            ~0 - Success
 
 -----------------------------------------------------------------------------*/
@@ -153,13 +153,13 @@ static const int mapCount = sizeof(nameMap) / sizeof(NameMap_t);
 
     v s i T r a n s l a t e N a m e
 
-	@brief Translate a CAN signal name to a VSS signal name.
+    @brief Translate a CAN signal name to a VSS signal name.
 
-	This function will translate a CAN signal name to a VSS signal name.
+    This function will translate a CAN signal name to a VSS signal name.
 
-	@param[in] CANname - The ASCII CAN name string.
+    @param[in] CANname - The ASCII CAN name string.
 
-	@return VSSname - The corresponding VSS name string.
+    @return VSSname - The corresponding VSS name string.
             NULL - If the CAN name could not be found in the translate table.
 
 -----------------------------------------------------------------------------*/
@@ -192,16 +192,16 @@ static const char* vsiTranslateName ( const char* CANname )
 
     v s i _ f i r e S i g n a l B y N a m e
 
-	@brief Send a signal to the VSI system using it's name.
+    @brief Send a signal to the VSI system using it's name.
 
-	This function will accept 2 arguments that are the name of the signal and
+    This function will accept 2 arguments that are the name of the signal and
     the integer value of the signal.  This information will be passed to the
     VSI system for storage and later retrieval.
 
-	@param[in] name - The ASCII name of the signal.
-	@param[in] value - The signed integer value of the signal (if any).
+    @param[in] name - The ASCII name of the signal.
+    @param[in] value - The signed integer value of the signal (if any).
 
-	@return status - 0 = Success
+    @return status - 0 = Success
                     ~0 = Errno
 
 -----------------------------------------------------------------------------*/


### PR DESCRIPTION
The source code had inconsistent indentation style, mixing spaces and
tabs.  Spaces were dominant and it is also what I prefer.  It was
possible to derive that a tab length (a.k.a. tabstop) of 4 has been used
so I have therefore assumed that it is the maintainer's desired
indentation step.

In the cases a tab was used in the middle of a line (or anywhere that
text was aligned to a column not divisible by 4), I tried to insert the
correct number of spaces to keep the same look as an editor with
tabstop=4 would show.  For example:

//  Text starts here
  ^^ Here a single tab ends up being shown as 2 spaces if tabstop=4

The code examples in api/README.md were also adjusted in the same way,
so that they are displayed properly regardless of tab size.