### PR TITLE
Fix for "Improper termination of names"

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ defines a 1MB system segment and a 2MB user segment by default.
 ## Running the Sample Executables
 
 To run the "sample" program, change directories to the
-"vehicle_signal_interface/api" directory and type "./sample".
+"vehicle_signal_interface/api" directory and type "./tests/sample".
 
 Similarly, going to the "vehicle_signal_interface/core/tests" directory will allow
 you to run the executables that were created in that directory.

--- a/api/vsi.c
+++ b/api/vsi.c
@@ -2142,7 +2142,7 @@ int vsi_define_signal_name ( vsi_handle     handle,
     //
     nameIdDefinition->name = sm_malloc ( strlen(name) + 1 );
     strncpy ( nameIdDefinition->name, name, strlen(name) );
-    nameIdDefinition->name[strlen(name)+1] = 0;
+    nameIdDefinition->name[strlen(name)] = 0;
 
     //
     //  Go insert the new id/name definition structure into both of the btree


### PR DESCRIPTION
#13 
included:
* updated sample executable path.
* corrected location of null character in signal name.