### PR TITLE
utils.c: Add guard on LOGs for pthread internals using VSI_DEBUG > 3

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -66,6 +66,7 @@ void dumpSemaphore ( semaphore_p semaphore )
     LOG ( "\nsemaphore: %p[%4p]\n", semaphore, (void*)((long)&semaphore->mutex % 0x10000 ) );
 #endif
 
+#if VSI_DEBUG > 3
     //
     //  Display our count values.
     //
@@ -99,6 +100,7 @@ void dumpSemaphore ( semaphore_p semaphore )
     LOG ( "   conditionVariable.data.broadcast_seq.: %d\n", semaphore->conditionVariable.__data.__broadcast_seq );
     LOG ( "   conditionVariable.size...............: 0x%llx\n", (long long)semaphore->conditionVariable.__size );
     LOG ( "   conditionVariable.align..............: %llx\n", semaphore->conditionVariable.__align );
+#endif
 
     fflush ( stdout );
 #endif


### PR DESCRIPTION
After discussion we concluded that logs were likely failing because they referenced internal struct members that have seemingly changed name in updated versions of a dependent library (libpthread, I suppose).

VSI_DEBUG now needs to be set to a value greater than 3 to compile & execute that part of the logs.  This simple solution was chosen because I was not sure of the long-term intention for these logs.

Consequently, note that setting VSI_DEBUG > 3 compilation is still likely to fail compilation on many systems, and the code would then need another update if you're interested in producing those logs.
