### PR TITLE
utils.c:  Add guard to LOG statements referring to internal vars

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -66,6 +66,7 @@ void dumpSemaphore ( semaphore_p semaphore )
     LOG ( "\nsemaphore: %p[%4p]\n", semaphore, (void*)((long)&semaphore->mutex % 0x10000 ) );
 #endif
 
+#if VSI_DEBUG > 3
     //
     //  Display our count values.
     //
@@ -119,6 +120,7 @@ void dumpSemaphore ( semaphore_p semaphore )
     LOG ( "   conditionVariable.align..............: %llx\n", semaphore->conditionVariable.__align );
 
     fflush ( stdout );
+#endif
 #endif
 #endif
     return;


### PR DESCRIPTION
Reopening this because the other fix in #25 still fails on ARM when compiling GDP.
Please see commit statement for details.
